### PR TITLE
templates: display notes for author records

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail_Author-Lists.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail_Author-Lists.html
@@ -95,7 +95,12 @@
           <div class="ui segment">
             <div class="card-body">
               {% block metadata_block %}
-              {% if record.title %}
+              {% if record.note %}
+              <div>
+                <h3 class="detail_view_h3">Description</h3>
+                <p>{{record.note.get("description", "") | safe}}</p>
+              </div>
+              {% elif record.title %}
               <div>
                 <h3 class="detail_view_h3">Description</h3>
                 <p>{{record.title | safe}}</p>


### PR DESCRIPTION
If an author record contains a note field, display it in the description rather than repeating the title.

Propagated from https://github.com/cernopendata/opendata.cern.ch/pull/3654