### PR TITLE
ci: move to docker compose v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2020, 2023 CERN.
+# Copyright (C) 2020, 2023, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -157,7 +157,7 @@ jobs:
         run: ./run-tests.sh --check-docker-build
 
       - name: Run pytest
-        run: docker-compose run --rm web ./run-tests.sh --check-pytest
+        run: docker compose run --rm web ./run-tests.sh --check-pytest
 
       - name: Codecov Coverage
         uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM registry.cern.ch/inveniosoftware/almalinux:1
 
-# Use XRootD 5.6.9
-ENV XROOTD_VERSION=5.6.9
+# Use XRootD 5.7.0
+ENV XROOTD_VERSION=5.7.0
 
 # Install CERN Open Data Portal web node pre-requisites
 # hadolint ignore=DL3033

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -104,7 +104,7 @@ check_manifest () {
 }
 
 check_docker_build () {
-    docker-compose build
+    docker compose build
 }
 
 check_pytest () {

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ install_requires = [
     # Pin Celery due to worker runtime issues
     "celery==5.2.7",
     # Pin XRootD consistently with Dockerfile
-    "xrootd==5.6.9",
+    "xrootd==5.7.0",
     # Pin Flask/gevent/greenlet/raven to make master work again
     "Flask==2.2.5",
     "Flask-Alembic==2.0.1",


### PR DESCRIPTION
Use docker-compose v2 as per the removal of v1 from GitHub Actions runners. <https://github.com/actions/runner-images/issues/9692>

Propagated from
<https://github.com/cernopendata/opendata.cern.ch/pull/3654>