### PR TITLE
templates: fix alphabetical order of experiments on the front page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2020, 2023 CERN.
+# Copyright (C) 2020, 2023, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -157,7 +157,7 @@ jobs:
         run: ./run-tests.sh --check-docker-build
 
       - name: Run pytest
-        run: docker-compose run --rm web ./run-tests.sh --check-pytest
+        run: docker compose run --rm web ./run-tests.sh --check-pytest
 
       - name: Codecov Coverage
         uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM registry.cern.ch/inveniosoftware/almalinux:1
 
-# Use XRootD 5.6.9
-ENV XROOTD_VERSION=5.6.9
+# Use XRootD 5.7.0
+ENV XROOTD_VERSION=5.7.0
 
 # Install CERN Open Data Portal web node pre-requisites
 # hadolint ignore=DL3033

--- a/cernopendata/templates/cernopendata_pages/front/main.html
+++ b/cernopendata/templates/cernopendata_pages/front/main.html
@@ -57,8 +57,8 @@
       <div class="collections-col">
         <header><span>Focus on</span></header>
         <ul>
-          <li><a href="/search?experiment=ATLAS">ATLAS</a></li>
           <li><a href="/search?experiment=ALICE">ALICE</a></li>
+          <li><a href="/search?experiment=ATLAS">ATLAS</a></li>
           <li><a href="/search?experiment=CMS">CMS</a></li>
           <li><a href="/search?experiment=DELPHI">DELPHI</a></li>
           <li><a href="/search?experiment=LHCb">LHCb</a></li>

--- a/nginx/localhost.conf
+++ b/nginx/localhost.conf
@@ -63,7 +63,7 @@ server {
 
     # Old reverse proxy to EOS locations used from COD2 times. (Not advertised
     # much in COD3 times anymore, but still useful to have.)
-    location ~* /eos/opendata/(alice|atlas|lhcb|cms|opera)/.*\.[a-zA-Z0-9]+$ {
+    location ~* /eos/opendata/(alice|atlas|cms|delphi|jade|lhcb|opera|phenix)/.*\.[a-zA-Z0-9]+$ {
         proxy_cache off;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -104,7 +104,7 @@ check_manifest () {
 }
 
 check_docker_build () {
-    docker-compose build
+    docker compose build
 }
 
 check_pytest () {

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ install_requires = [
     # Pin Celery due to worker runtime issues
     "celery==5.2.7",
     # Pin XRootD consistently with Dockerfile
-    "xrootd==5.6.9",
+    "xrootd==5.7.0",
     # Pin Flask/gevent/greenlet/raven to make master work again
     "Flask==2.2.5",
     "Flask-Alembic==2.0.1",


### PR DESCRIPTION
Fixes order of experiments in the "Focus on" list on the front page to
be truly alphabetical.

Propagated from
<https://github.com/cernopendata/opendata.cern.ch/pull/3654>
