### PR TITLE
record_ui: add link to inspire for datasets that have publications

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -78,13 +78,14 @@ APP_DEFAULT_SECURE_HEADERS = {
     "strict_transport_security_max_age": 31556926,  # One year in seconds
     "strict_transport_security_include_subdomains": True,
     "content_security_policy": {
-        "default-src": ["'self'"],
+        "default-src": ["'self'", "https://inspirehep.net/",],
         "object-src": ["'none'"],
         "script-src": [
             "'self'",
             "'unsafe-eval'",
             "'unsafe-inline'",
             "https://cdnjs.cloudflare.com",
+            "https://inspirehep.net/",
         ],
         "font-src": [
             "'self'",

--- a/cernopendata/modules/theme/assets/semantic-ui/js/records/CitationsApp.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/records/CitationsApp.js
@@ -2,7 +2,7 @@
  * -*- coding: utf-8 -*-
  *
  * This file is part of CERN Open Data Portal.
- * Copyright (C) 2021 CERN.
+ * Copyright (C) 2024 CERN.
  *
  * CERN Open Data Portal is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public License as
@@ -24,16 +24,33 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
 
-import FilesBoxApp from "./FilesBoxApp";
+import React, { useEffect, useState } from "react";
+const CitationsApp = () => {
+  const [references, setReferences] = useState(0);
 
-import CitationsApp from "./CitationsApp";
+  const doi = document.querySelector("#citations-react-app").getAttribute("data-doi");
+  const recid = document.querySelector("#citations-react-app").getAttribute("data-recid");
+  
+  const inspireHost = "https://inspirehep.net"
+  const inspireURL = `/literature?sort=mostrecent&size=25&page=1&q=references.reference.dois%3A${doi}%20or%20references.reference.urls.value%3Ahttps%3A%2F%2Fopendata.cern.ch%2Frecord%2F${recid}`;
+  const inspireFullPath = `${inspireHost}${inspireURL}`;
 
-const citeContainer = document.querySelector("#citations-react-app");
-ReactDOM.render(React.createElement(CitationsApp), citeContainer);
+  useEffect(() => {
+    fetch(`${inspireHost}/api${inspireURL}`)
+      .then((response) => response.json())
+      .then((data) => {
+        setReferences(data.hits.total);
+      });
+  }, []);
 
-const domContainer = document.querySelector("#files-box-react-app");
-ReactDOM.render(React.createElement(FilesBoxApp), domContainer);
+  return (
+    <>
+        { references > 0 &&
+          <a href={inspireFullPath}>There are {references} publications referring to these data</a>
+        }
+    </>
+  );
+};
 
+export default CitationsApp;

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -46,6 +46,7 @@
             {% if record.date_published %} ({{ record.date_published }}). {% endif %}
             {{ record.title_additional or record.title }}. CERN Open Data Portal.
             DOI:<a href="http://doi.org/{{record.doi}}">{{record.doi}}</a>
+            <div id="citations-react-app" data-doi={{ record.doi }} data-recid={{record.recid}}></div>
         </span>
     </p>
     {% endif %}


### PR DESCRIPTION
The landing page of a record will make a call to inspire to see if there are publications for this DOI. If so, it will add a link to it.