### PR TITLE
Search: fixed focus on to use correct urls

### DIFF
--- a/cernopendata/templates/cernopendata_pages/front/main.html
+++ b/cernopendata/templates/cernopendata_pages/front/main.html
@@ -57,8 +57,8 @@
       <div class="collections-col">
         <header><span>Focus on</span></header>
         <ul>
-          {% for id, exp in experiments_display.items() %}
-            <li><a href="/search?experiment={{ id }}">{{ exp.name }}</a></li>
+          {% for exp in experiments_display.values() %}
+            <li><a href="/search?experiment={{ exp.name }}">{{ exp.name }}</a></li>
           {% endfor %}
           <li><a href="/search?keywords=datascience">Data Science</a></li>
         </ul>


### PR DESCRIPTION
URLs now have correct letter cases in the "Focus on" section.