### PR TITLE
fixtures: Fix a bug where the update_record was removing the bucket

### DIFF
--- a/cernopendata/modules/fixtures/cli.py
+++ b/cernopendata/modules/fixtures/cli.py
@@ -137,8 +137,10 @@ def update_record(pid, data, skip_files):
             FileInstance.query.filter_by(id=o.file_id).delete()
         FileIndexMetadata.delete_by_record(record=record)
     # This is to ensure that fields that do not appear in the new data
-    # are not just maintained from the previous version
+    # are not just kept from the previous version
     for k in list(record.keys()):
+        if k == "_bucket":
+            continue
         if skip_files and k in ["files", "_files", "file_indices", "_file_indices"]:
             continue
         del record[k]


### PR DESCRIPTION
The following scenario used to fail:
```
1. Insert a record with files. This worked fine
2. Update the record a first time. This seemed to work fine, but removed the '_bucket' field from the record. That mean that any following updates were not able to clean up the old files before inserting the new entry
3. Update the record a second time. This one gave an error that the files already existed. 
```

The PR addresses this issue, including a test to make sure that it does not happen again