### PR TITLE
Add RSS endpoint for news

### DIFF
--- a/cernopendata/modules/api/news.py
+++ b/cernopendata/modules/api/news.py
@@ -1,0 +1,59 @@
+"""News endpoint accessible via the CERN Open Data Portal API"""
+
+from datetime import datetime
+
+from flask import Blueprint, Response, request
+
+from ..pages.utils import FeaturedArticlesSearch
+
+blueprint = Blueprint("cernopendata_api_news", __name__)
+
+
+@blueprint.route("/news.xml", methods=["GET"])
+def get_latest_news():
+    """Returns the set amount of latest news from the Open Data Portal"""
+    limit = request.args.get('limit', default=10, type=int)
+    limit = min(abs(limit), 128)
+
+    try:
+        news = FeaturedArticlesSearch().sort("-date_published")[:limit].execute().hits.hits
+    except Exception:
+        news = []
+
+    rss_items = "\n".join(
+        [
+            f"""
+            <item>
+                <title>{article.get("title", "CERN Open Data update")}</title>
+                <link>
+                    https://opendata.cern.ch/docs/{article.get("slug", "")}
+                </link>
+                <pubDate>{
+                    datetime.strptime(article.get("date_published", "2000-01-01"), "%Y-%m-%d")
+                    .strftime("%a, %d %b %Y 00:00:00 +0000")
+                }</pubDate>
+                <description>
+                    Author: {article.get("author", "Open Data Portal team")}
+                </description>   
+            </item>
+            """
+            for a in news
+            if (article := a.get("_source"))
+        ]
+    )
+
+    rss_feed = f"""<?xml version="1.0" encoding="UTF-8" ?>
+    <rss version="2.0">
+        <channel>
+            <title>CERN Open Data RSS News</title>
+            <link>https://opendata.cern.ch/</link>
+            <description>
+                Latest news from CERN Open Data
+            </description>
+            <language>en</language>
+            {rss_items}
+        </channel>
+    </rss>
+    """
+
+    return Response(rss_feed, mimetype="application/xml")

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,9 @@ setup(
         "invenio_base.api_apps": [
             "cernopendata_xrootd = cernopendata.modules.xrootd:CODPXRootD"
         ],
+        "invenio_base.api_blueprints": [
+            "cernopendata_news_api = cernopendata.modules.api.news:blueprint",
+        ],
         "invenio_base.blueprints": [
             "cernopendata = cernopendata.views:blueprint",
             "cernopendata_pages = " "cernopendata.modules.pages.views:blueprint",


### PR DESCRIPTION
For implementing a news banner in Grafana on the landing page, it would be a nice addition to display the news from the main Open Data page. The returned XML should conform the RSS standards, similar to Grafana's default feed [xml file](https://grafana.com/blog/news.xml).