### PR TITLE
cold_data: Store multiple uri for a single file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM registry.cern.ch/inveniosoftware/almalinux:1
 
-# Use XRootD 5.7.2
-ENV XROOTD_VERSION=5.7.2
+# Use XRootD 5.7.3
+ENV XROOTD_VERSION=5.7.3
 
 # Install CERN Open Data Portal web node pre-requisites
 # hadolint ignore=DL3033

--- a/cernopendata/modules/search/component_templates/os-v2/opendata-common-v1.0.0.json
+++ b/cernopendata/modules/search/component_templates/os-v2/opendata-common-v1.0.0.json
@@ -18,6 +18,9 @@
         "accelerator": {
           "type": "keyword"
         },
+        "availability": {
+          "type": "keyword"
+        },
         "date_created": {
           "type": "keyword"
         },

--- a/cernopendata/modules/search/component_templates/os-v2/opendata-record-v1.0.0.json
+++ b/cernopendata/modules/search/component_templates/os-v2/opendata-record-v1.0.0.json
@@ -188,6 +188,9 @@
         },
         "files": {
           "properties": {
+            "availability": {
+              "type": "keyword"
+            },
             "bucket": {
               "type": "text"
             },
@@ -207,6 +210,9 @@
               "type": "keyword"
             },
             "uri": {
+              "type": "text"
+            },
+            "uri_cold": {
               "type": "text"
             },
             "version_id": {

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ install_requires = [
     # Pin Celery due to worker runtime issues
     "celery==5.2.7",
     # Pin XRootD consistently with Dockerfile
-    "xrootd==5.7.1",
+    "xrootd==5.7.3",
     # Pin Flask/gevent/greenlet/raven to make master work again
     "Flask==2.2.5",
     "Flask-Alembic==2.0.1",


### PR DESCRIPTION
Adding a new class inheriting from FileObject that allows two urls for an entry. It also calculates the availability of a file (depending if the `hot` url has a value`), and for a record, which goes through all the files in that record. 

The availability for a record is defined with the following formula:
```
If the record has no files, and it has the field 'distribution.availability':
    avl = record.distribution.availability #At the moment, this is used for ondemand
if the record has files:
   if all the files are in the same state:
       avl = record.file[0].availability. # If all the files are online, or all ondemand
   else
      avl = 'sample files'
```

  