### PR TITLE
build(docker): remove obsoleted compose version attribute

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,8 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-version: "3"
-
 services:
   web:
     restart: "unless-stopped"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-version: "3"
-
 x-common-variables: &common-variables
   INVENIO_ACCOUNTS_REGISTER_BLUEPRINT: None
   INVENIO_ACCOUNTS_SESSION_REDIS_URL: redis://cache:6379/1


### PR DESCRIPTION
Fixes an observation during `docker compose up`:

```
WARN[0000] /.../cernopendata-portal/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

```