### PR TITLE
schema: ensuring that the records do not add any additional properties

### DIFF
--- a/cernopendata/jsonschemas/records/docs-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/docs-v1.0.0.json
@@ -1,42 +1,21 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
   "description": "Describe information needed for article entity.",
   "properties": {
-    "_files": {
-      "items": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "description": "Describe information needed for files in records.",
-        "properties": {
-          "bucket": {
-            "type": "string"
-          },
-          "checksum": {
-            "type": "string"
-          },
-          "key": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "uri": {
-            "type": "string"
-          },
-          "version_id": {
-            "type": "string"
-          }
-        },
-        "title": "File schema.",
-        "type": "object"
-      },
-      "type": "array"
+    "$schema": {
+      "type": "string"
     },
     "author": {
       "type": "string"
     },
     "body": {
+      "additionalProperties": false,
       "properties": {
         "content": {
+          "type": "string"
+        },
+        "format": {
           "type": "string"
         },
         "type": {
@@ -72,6 +51,7 @@
     },
     "related": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "string"
@@ -87,7 +67,11 @@
     "screenshot": {
       "type": "string"
     },
+    "slug": {
+      "type": "string"
+    },
     "short_description": {
+      "additionalProperties": false,
       "properties": {
         "content": {
           "type": "string"
@@ -99,6 +83,7 @@
       "type": "object"
     },
     "stripping": {
+      "additionalProperties": false,
       "properties": {
         "stream": {
           "description": "Stripping stream information, used notably by LHCb",
@@ -122,6 +107,7 @@
       "type": "string"
     },
     "type": {
+      "additionalProperties": false,
       "properties": {
         "primary": {
           "type": "string"

--- a/cernopendata/jsonschemas/records/glossary-term-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/glossary-term-v1.0.0.json
@@ -1,7 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
   "description": "Describe information needed for glossary term entity.",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "accelerator": {
+      "title": "Accelerator",
+      "type": "string"
+    },
     "anchor": {
       "title": "Anchor",
       "type": "string"
@@ -31,6 +39,7 @@
     },
     "links": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "text": {
             "title": "Text",
@@ -48,6 +57,7 @@
     },
     "see_also": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "term": {
             "title": "Term",
@@ -71,6 +81,7 @@
       "type": "array"
     },
     "type": {
+      "additionalProperties": false,
       "properties": {
         "primary": {
           "type": "string"

--- a/cernopendata/jsonschemas/records/record-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/record-v1.0.0.json
@@ -1,10 +1,32 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
   "description": "Record",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "_availability_details": {
+      "additionalProperties": false,
+      "properties": {
+        "on demand": {
+          "type": "integer"
+        },
+        "online": {
+          "type": "integer"
+        }
+      }
+    },
+    "_bucket": {
+      "type": "string"
+    },
     "_files": {
       "items": {
+        "additionalProperties": false,
         "properties": {
+          "availability": {
+            "type": "string"
+          },
           "bucket": {
             "type": "string"
           },
@@ -14,11 +36,16 @@
           "description": {
             "type": "string"
           },
+          "file_id": {
+            "type": "string"
+          },
           "key": {
             "type": "string"
           },
           "size": {
             "type": "integer"
+          },
+          "tags": {
           },
           "type": {
             "type": "string"
@@ -35,7 +62,14 @@
       "type": "array",
       "uniqueItems": true
     },
+    "_file_indices": {
+      "type": "array"
+    },
+    "availability": {
+      "type": "string"
+    },
     "abstract": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "A summary of the resource",
@@ -43,6 +77,7 @@
         },
         "links": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "A brief description of the link associated with the abstract",
@@ -74,6 +109,7 @@
     },
     "authors": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "affiliation": {
             "description": "The affiliation of the author. Multiple affiliations are separated by a semicolon (;)",
@@ -105,6 +141,7 @@
       "type": "array"
     },
     "categories": {
+      "additionalProperties": false,
       "properties": {
         "primary": {
           "description": "Primary category of the simulated dataset or related asset",
@@ -129,6 +166,7 @@
       "type": "string"
     },
     "collaboration": {
+      "additionalProperties": false,
       "properties": {
         "group": {
           "description": "The name of the group the author is part of",
@@ -153,6 +191,7 @@
       "type": "array"
     },
     "collision_information": {
+      "additionalProperties": false,
       "properties": {
         "energy": {
           "description": "Collision energy e.g. 8TeV",
@@ -166,13 +205,20 @@
       "type": "object"
     },
     "cross_section": {
+      "additionalProperties": false,
       "properties": {
         "filter_efficiency": {
           "description": "Cross section filter efficiency as given by GenXSecAnalyser",
           "type": "string"
         },
+        "filter_efficiency_error":{
+          "type": "string"
+        },
         "matching_efficiency": {
           "description": "Cross section matching efficiency as given by GenXSecAnalyser",
+          "type": "string"
+        },
+        "matching_efficiency_error": {
           "type": "string"
         },
         "neg_weight_fraction": {
@@ -191,6 +237,7 @@
       "type": "object"
     },
     "dataset_semantics_files": {
+      "additionalProperties": false,
       "properties": {
         "url": {
           "description": "Url of the dataset content description html file",
@@ -207,6 +254,7 @@
       "additionalProperties" : {
           "type": "array",
           "items": {
+            "additionalProperties": false,
             "properties": {
               "key": {
                 "type": "string"
@@ -229,6 +277,7 @@
     },
     "dataset_semantics": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Description or explanation for a variable",
@@ -267,6 +316,7 @@
       "type": "string"
     },
     "distribution": {
+      "additionalProperties": false,
       "properties": {
         "availability": {
           "description": "Specifies if dataset is on-demand, online in future might be also tape, disk",
@@ -313,6 +363,40 @@
       },
       "type": "array"
     },
+    "files": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "availability": {
+            "type": "string"
+          },
+          "bucket": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "description":{
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "keywords": {
       "items": {
         "description": "Relevant keywords for the record",
@@ -325,6 +409,7 @@
       "type": "string"
     },
     "license": {
+      "additionalProperties": false,
       "properties": {
         "attribution": {
           "description": "The license this resource is published under. Most of the content in the portal is released under the Creative Commons CC0 waiver and, if the resource is software, under another open-source license (usually GNU General Public License or Apache)",
@@ -335,6 +420,7 @@
     },
     "links": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "A brief description of the link",
@@ -362,6 +448,7 @@
       "type": "string"
     },
     "methodology": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "A description of the methodology used for the production of this data/software",
@@ -369,6 +456,7 @@
         },
         "links": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "A brief description of the link associated with the methodology",
@@ -391,13 +479,23 @@
           },
           "type": "array"
         },
+        "note": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            }
+          }
+        },
         "steps": {
           "items": [
             {
+              "additionalProperties": false,
               "properties": {
                 "configuration_files": {
                   "items": [
                     {
+                      "additionalProperties": false,
                       "properties": {
                         "cms_confdb_id": {
                           "description": "the cms_confdb_id (applies to CMS records)",
@@ -442,6 +540,28 @@
                   "description": "The global tag for generator",
                   "type": "string"
                 },
+                "note": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "links":{
+                      "type": "array",
+                      "items": [{
+                        "additionalProperties": false,
+                        "properties": {
+                          "recid": {
+                            "type": "string"
+                          }
+                        }
+                      }
+
+                      ]
+                    }
+
+                  }
+                },
                 "output_dataset": {
                   "description": "Output for production",
                   "type": "string"
@@ -463,7 +583,44 @@
       },
       "type": "object"
     },
+    "note": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "links":{
+          "type": "array",
+          "items": [{
+            "additionalProperties": false,
+            "properties": {
+              "recid": {
+                "type": "string"
+              }
+            }
+          }
+
+          ]
+        }
+
+      }
+    },
+    "pids":{
+      "additionalProperties": false,
+      "properties": {
+        "oai": {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+
+      }
+    },
     "pileup": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "Note about pile-up events (applies to simulated records",
@@ -471,6 +628,7 @@
         },
         "links": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "A brief description of the link associated with the pile-up information",
@@ -497,6 +655,7 @@
       "type": "object"
     },
     "prepublication": {
+      "additionalProperties": false,
       "properties": {
         "date": {
           "description": "The prepublication date, based on ISO 8601 (YYYY-MM-DD)",
@@ -527,6 +686,7 @@
     },
     "relations": {
       "items": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "A description about the related dataset",
@@ -574,7 +734,8 @@
       },
       "type": "array"
     },
-    "source code repository": {
+    "source_code_repository": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "A description text for the source code repository",
@@ -588,7 +749,11 @@
       "type": "object"
     },
     "stripping": {
+      "additionalProperties": false,
       "properties": {
+        "line": {
+          "type": "string"
+        },
         "stream": {
           "description": "Stripping stream information, used notably by LHCb",
           "type": "string"
@@ -601,9 +766,11 @@
       "type": "object"
     },
     "system_details": {
+      "additionalProperties": false,
       "properties": {
         "container_images": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "Description of the container image that is recommended for analysing these data",
@@ -655,6 +822,7 @@
       "type": "string"
     },
     "type": {
+      "additionalProperties": false,
       "properties": {
         "primary": {
           "description": "The primary category this resource belongs to (what appears in the UI facets)",
@@ -671,6 +839,7 @@
       "type": "object"
     },
     "usage": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "Instructions on how this resource can be used/accessed",
@@ -678,6 +847,7 @@
         },
         "links": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "A brief description of the link associated with the usage information",
@@ -704,6 +874,7 @@
       "type": "object"
     },
     "use_with": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "Information regarding other resources that can be used alongside this one",
@@ -711,6 +882,7 @@
         },
         "links": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "A brief description of the link associated with the use-with information",
@@ -737,6 +909,7 @@
       "type": "object"
     },
     "validation": {
+      "additionalProperties": false,
       "properties": {
         "description": {
           "description": "Information regarding the validation process this resource has undergone",
@@ -744,6 +917,7 @@
         },
         "links": {
           "items": {
+            "additionalProperties": false,
             "properties": {
               "description": {
                 "description": "A brief description of the link associated with the validation information",

--- a/scripts/start-server-debug.sh
+++ b/scripts/start-server-debug.sh
@@ -16,4 +16,4 @@ else
   cernopendata run -h 0.0.0.0 --reload;
 fi
 echo "THE WEB SERVICE DIED!!! Let's sleep for a bit to give some time to debug"
-sleep 60
+sleep 600

--- a/scripts/validate_json.py
+++ b/scripts/validate_json.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+from jsonschema import Draft7Validator
+
+
+def load_schema(schema_path):
+    with open(schema_path) as f:
+        return json.load(f)
+
+
+def validate_files(schema, file_paths):
+    validator = Draft7Validator(schema)
+    total_processed = 0
+
+    for file_path in file_paths:
+        #        print(f"Processing file: {file_path}", file=sys.stderr)
+
+        with open(file_path) as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                print(f"❌ Failed to parse file {file_path}: {e}")
+                continue
+
+        if not isinstance(data, list):
+            print(f"❌ File {file_path} does not contain a JSON list")
+            continue
+
+        for idx, item in enumerate(data):
+            total_processed += 1
+
+            errors = list(validator.iter_errors(item))
+            if errors:
+                print(f"❌ File: {file_path}, item #{idx}")
+                for e in errors:
+                    path = ".".join(str(p) for p in e.path)
+                    print(f"   - {path or '<root>'}: {e.message}")
+
+            # Heartbeat every 1000 records
+            if total_processed % 1000 == 0:
+                print(
+                    f"[heartbeat] Processed {total_processed} records", file=sys.stderr
+                )
+
+    print(f"Done. Total records processed: {total_processed}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: validate.py schema.json file1.json file2.json ...")
+        sys.exit(1)
+
+    schema_path = sys.argv[1]
+    file_paths = sys.argv[2:]
+
+    schema = load_schema(schema_path)
+    validate_files(schema, file_paths)

--- a/tests/test_controlNumber.py
+++ b/tests/test_controlNumber.py
@@ -14,14 +14,14 @@ def test_update_doc(app, database):
         "$schema": app.extensions["invenio-jsonschemas"].path_to_url(
             "records/glossary-term-v1.0.0.json"
         ),
-        "old_field": "value_to_delete",
+        "category": "value_to_delete",
     }
 
     record = create_glossary_term(data, False)
     print("Record created")
     print(record)
 
-    assert record["old_field"]
+    assert record["category"]
 
     pid_object = PersistentIdentifier.get("termid", "dummy_anchor")
     new_data = {
@@ -29,10 +29,10 @@ def test_update_doc(app, database):
         "$schema": app.extensions["invenio-jsonschemas"].path_to_url(
             "records/glossary-term-v1.0.0.json"
         ),
-        "new_field": "value_to_keep",
+        "accelerator": "value_to_keep",
     }
     record = update_doc_or_glossary(pid_object, new_data, False)
     print("Record updated")
     print(record)
-    assert "old_field" not in record.keys()
-    assert record["new_field"]
+    assert "category" not in record.keys()
+    assert record["accelerator"]


### PR DESCRIPTION
This solves most of the json schemas issues, and ensure that new items do not add new fields. 

Note that there are a couple of entries with fields that do not validate (and the fields look like typos):

❌ File: /content/data/records/cms-simulated-datasets-2012.json, item #560
   - cross_section: Additional properties are not allowed ('filter_efficiency_error:', 'matching_efficiency_error:' were unexpected)
❌ File: /content/data/records/cms-simulated-datasets-2012.json, item #2440
   - cross_section: Additional properties are not allowed ('filter_efficiency_error:' was unexpected)
❌ File: /content/data/records/jade-author-list.json, item #0
   - <root>: Additional properties are not allowed ('description' was unexpected)
   
   Those ones should be corrected in the opendata repository