### PR TITLE
fix: improve lighthouse scoring

### DIFF
--- a/cernopendata/modules/globals/ext.py
+++ b/cernopendata/modules/globals/ext.py
@@ -43,7 +43,6 @@ class GlobalVariables:
         "totem": {
             "name": "TOTEM",
             "url": "totem-experiment.web.cern.ch",
-            "width": "auto",
         },
     }
 

--- a/cernopendata/modules/pages/views.py
+++ b/cernopendata/modules/pages/views.py
@@ -90,7 +90,9 @@ def index():
     except Exception:
         pass
     return render_template(
-        "cernopendata_pages/front/index.html", featured_articles=results
+        "cernopendata_pages/front/index.html",
+        featured_articles=results,
+        description="Portal to the High Energy Physics data from CERN",
     )
 
 

--- a/cernopendata/templates/cernopendata_theme/footer.html
+++ b/cernopendata/templates/cernopendata_theme/footer.html
@@ -9,7 +9,7 @@
               <img
                 src="{{ url_for('static', filename='img/experiments/{}.gif'.format(id)) }}"
                 alt="{{ exp.name }} experiment"
-                width="{{ exp.get('width', 55) }}"
+                width="{{ exp.get('width', 'auto') }}"
                 height="{{ exp.get('height', 55) }}"
               />
             </a>

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -4,11 +4,6 @@
     {{ super() }}
     {{ webpack['cernopendata_css.css'] }}
     {{ webpack['glossary_css.css'] }}
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
 {%- endblock css %}
 
 {%- block bypasslinks %}
@@ -72,8 +67,6 @@
         "HTML-CSS": { availableFonts: ["TeX"], matchFontHeight: false }
       });
     </script>
-
-    <script type="text/javascript" src="{{ config['THEME_MATHJAX_CDN'] }}"></script>
   {% endblock %}
 
   {%- block jsonld_serialization %}{%- endblock jsonld_serialization %}

--- a/nginx/localhost.conf
+++ b/nginx/localhost.conf
@@ -59,6 +59,13 @@ server {
 
     location /static {
         root /opt/invenio/var/instance;
+        # Cache for 30 days
+        expires 30d;
+        # Cache-Control header
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        # Compress
+        gzip on;
+        gzip_types text/css application/javascript;
     }
 
     # Old reverse proxy to EOS locations used from COD2 times. (Not advertised


### PR DESCRIPTION
Couple of minor fixes:
* Keep the ratio of the experiment logos
* Define: Meta-description in the home page
* Remove duplicate declaration of scripts
* Define TTL for the static content