### PR TITLE
feat(releases): add DOI validation

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -814,8 +814,11 @@ OAUTH_REMOTE_APP_NAME = "cern_openid"
 OAUTHCLIENT_REMOTE_APPS = {
     cern_remote_app_name: cern_keycloak.remote_app,
 }
+
+INSTANCE_NAME = os.environ.get("CERNOPENDATA_CERN_APP_NAME", "opendata-dev")
+
 CERN_APP_CREDENTIALS = {
-    "consumer_key": os.environ.get("CERNOPENDATA_CERN_APP_NAME", "opendata-dev"),
+    "consumer_key": INSTANCE_NAME,
     "consumer_secret": os.environ.get(
         "CERNOPENDATA_CERN_APP_CREDENTIALS", "<CHANGEME>"
     ),

--- a/cernopendata/modules/releases/validations/doi.py
+++ b/cernopendata/modules/releases/validations/doi.py
@@ -1,0 +1,99 @@
+"""Validation that record DOIs use the correct prefix and have unique suffixes."""
+
+from flask import current_app
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+
+from ...datacite.utils import generate_doi
+from .base import Validation
+
+
+class ValidDoi(Validation):
+    """Check that record DOIs use the correct prefix and have unique suffixes."""
+
+    name = "Valid DOI"
+    error_message = "DOIs must use the correct prefix and have a unique suffix."
+    applies_to = {"records"}
+
+    def _validate_prefix(self):
+        """Return True only on the production instance, where DOI prefixes are validated."""
+        return current_app.config["INSTANCE_NAME"] == "opendata"
+
+    def validate(self, release):
+        """Check the prefix and suffix uniqueness of every record that has a DOI."""
+        prefix = str(current_app.config.get("PIDSTORE_DATACITE_DOI_PREFIX"))
+        validate_prefix = self._validate_prefix()
+        errors = []
+        used_suffixes = {}
+        for i, record in enumerate(release.records or []):
+            doi = record.get("doi")
+            if not doi:
+                continue
+            doi_prefix, separator, suffix = doi.partition("/")
+            if not separator or not suffix:
+                errors.append(f"Entry {i + 1}: Malformed DOI '{doi}'")
+                continue
+            if validate_prefix and doi_prefix != prefix:
+                errors.append(
+                    f"Entry {i + 1}: DOI prefix '{doi_prefix}' does not match "
+                    f"the prefix '{prefix}'"
+                )
+            if suffix in used_suffixes:
+                errors.append(
+                    f"Entry {i + 1}: Duplicate DOI suffix '{suffix}' "
+                    f"(also used by entry {used_suffixes[suffix] + 1})"
+                )
+            else:
+                used_suffixes[suffix] = i
+
+        for suffix in self._registered_suffixes(prefix, list(used_suffixes)):
+            errors.append(f"DOI suffix already registered: {suffix}")
+
+        return errors
+
+    def fix(self, release):
+        """Replace invalid DOIs.
+
+        - in case of an invalid, duplicate or missing suffix, mint a new DOI
+        - wrong prefix is validated and replaced only in production
+        """
+        prefix = str(current_app.config.get("PIDSTORE_DATACITE_DOI_PREFIX"))
+        validate_prefix = self._validate_prefix()
+        records = release.records or []
+
+        all_suffixes = [
+            record["doi"].partition("/")[2]
+            for record in records
+            if record.get("doi") and "/" in record["doi"]
+        ]
+        registered_suffixes = set(self._registered_suffixes(prefix, all_suffixes))
+
+        used_suffixes = set()
+        for record in records:
+            doi = record.get("doi")
+            if not doi:
+                continue
+            doi_prefix, separator, suffix = doi.partition("/")
+            if not separator or not suffix:
+                record["doi"] = generate_doi(prefix, release.experiment)
+                used_suffixes.add(record["doi"].partition("/")[2])
+                continue
+            if validate_prefix and doi_prefix != prefix:
+                record["doi"] = f"{prefix}/{suffix}"
+            if suffix in used_suffixes or suffix in registered_suffixes:
+                record["doi"] = generate_doi(prefix, release.experiment)
+                suffix = record["doi"].partition("/")[2]
+            used_suffixes.add(suffix)
+        return self.validate(release)
+
+    @staticmethod
+    def _registered_suffixes(prefix, suffixes):
+        """Return suffixes whose '{prefix}/{suffix}' DOI is already a registered PID."""
+        if not suffixes:
+            return []
+        candidates = {f"{prefix}/{suffix}": suffix for suffix in suffixes}
+        existing = PersistentIdentifier.query.filter(
+            PersistentIdentifier.pid_type == "doi",
+            PersistentIdentifier.pid_value.in_(list(candidates)),
+            PersistentIdentifier.status == PIDStatus.REGISTERED,
+        ).all()
+        return [candidates[pid.pid_value] for pid in existing]

--- a/tests/releases/test_validator_doi.py
+++ b/tests/releases/test_validator_doi.py
@@ -1,0 +1,135 @@
+from unittest.mock import patch
+
+import pytest
+
+from cernopendata.modules.releases.validations.doi import ValidDoi
+
+TEST_PREFIX = "10.5072"
+WRONG_PREFIX = "10.9999"
+SUFFIX = "OPENDATA.CMS.AB12.CD34"
+
+
+class DummyRelease:
+    def __init__(self, records, experiment="CMS"):
+        self.records = records
+        self.experiment = experiment
+
+
+def _config(instance_name):
+    return {
+        "PIDSTORE_DATACITE_DOI_PREFIX": TEST_PREFIX,
+        "INSTANCE_NAME": instance_name,
+    }
+
+
+@pytest.fixture
+def patched_prefix():
+    with patch("cernopendata.modules.releases.validations.doi.current_app") as mock_app:
+        mock_app.config = _config("opendata")
+        yield
+
+
+@pytest.fixture
+def patched_prefix_nonprod():
+    with patch("cernopendata.modules.releases.validations.doi.current_app") as mock_app:
+        mock_app.config = _config("opendata-dev")
+        yield
+
+
+@pytest.mark.parametrize(
+    "records, registered, expected",
+    [
+        ([{"recid": "CMS-1"}, {"recid": "CMS-2"}], [], None),
+        ([{"recid": "CMS-1", "doi": "not-a-doi"}], [], "Malformed DOI"),
+        ([{"recid": "CMS-1", "doi": f"{WRONG_PREFIX}/{SUFFIX}"}], [], "does not match"),
+        (
+            [
+                {"recid": "CMS-1", "doi": f"{TEST_PREFIX}/{SUFFIX}"},
+                {"recid": "CMS-2", "doi": f"{TEST_PREFIX}/{SUFFIX}"},
+            ],
+            [],
+            "Duplicate DOI suffix",
+        ),
+        (
+            [{"recid": "CMS-1", "doi": f"{TEST_PREFIX}/{SUFFIX}"}],
+            [SUFFIX],
+            "already registered",
+        ),
+        ([{"recid": "CMS-1", "doi": f"{TEST_PREFIX}/{SUFFIX}"}], [], None),
+    ],
+)
+def test_validate(patched_prefix, records, registered, expected):
+    validator = ValidDoi()
+    release = DummyRelease(records)
+    with patch.object(validator, "_registered_suffixes", return_value=registered):
+        errors = validator.validate(release)
+    if expected is None:
+        assert errors == []
+    else:
+        assert len(errors) == 1
+        assert expected in errors[0]
+
+
+def test_fix_corrects_prefix_and_mints_duplicate(patched_prefix):
+    minted = f"{TEST_PREFIX}/OPENDATA.CMS.ZZZZ.9999"
+    validator = ValidDoi()
+    release = DummyRelease(
+        [
+            {"recid": "CMS-0"},
+            {"recid": "CMS-1", "doi": f"{WRONG_PREFIX}/{SUFFIX}"},
+            {"recid": "CMS-2", "doi": f"{TEST_PREFIX}/{SUFFIX}"},
+        ]
+    )
+    with patch.object(validator, "_registered_suffixes", return_value=[]), patch(
+        "cernopendata.modules.releases.validations.doi.generate_doi",
+        return_value=minted,
+    ):
+        errors = validator.fix(release)
+    assert "doi" not in release.records[0]
+    assert release.records[1]["doi"] == f"{TEST_PREFIX}/{SUFFIX}"
+    assert release.records[2]["doi"] == minted
+    assert errors == []
+
+
+def test_fix_mints_new_doi_for_malformed(patched_prefix):
+    minted = f"{TEST_PREFIX}/OPENDATA.CMS.ZZZZ.9999"
+    validator = ValidDoi()
+    release = DummyRelease([{"recid": "CMS-1", "doi": "not-a-doi"}])
+    with patch.object(validator, "_registered_suffixes", return_value=[]), patch(
+        "cernopendata.modules.releases.validations.doi.generate_doi",
+        return_value=minted,
+    ):
+        errors = validator.fix(release)
+    assert release.records[0]["doi"] == minted
+    assert errors == []
+
+
+def test_validate_allows_wrong_prefix_in_non_production(patched_prefix_nonprod):
+    validator = ValidDoi()
+    release = DummyRelease([{"recid": "CMS-1", "doi": f"{WRONG_PREFIX}/{SUFFIX}"}])
+    with patch.object(validator, "_registered_suffixes", return_value=[]):
+        assert validator.validate(release) == []
+
+
+def test_fix_keeps_wrong_prefix_in_non_production(patched_prefix_nonprod):
+    validator = ValidDoi()
+    release = DummyRelease([{"recid": "CMS-1", "doi": f"{WRONG_PREFIX}/{SUFFIX}"}])
+    with patch.object(validator, "_registered_suffixes", return_value=[]):
+        assert validator.fix(release) == []
+    assert release.records[0]["doi"] == f"{WRONG_PREFIX}/{SUFFIX}"
+
+
+def test_registered_suffixes_empty():
+    assert ValidDoi._registered_suffixes(TEST_PREFIX, []) == []
+
+
+def test_registered_suffixes_matches_existing():
+    class FakePid:
+        pid_value = f"{TEST_PREFIX}/{SUFFIX}"
+
+    with patch(
+        "cernopendata.modules.releases.validations.doi.PersistentIdentifier"
+    ) as mock_pid:
+        mock_pid.query.filter.return_value.all.return_value = [FakePid()]
+        result = ValidDoi._registered_suffixes(TEST_PREFIX, [SUFFIX])
+    assert result == [SUFFIX]


### PR DESCRIPTION
Resolves #339 

In case the prefix does not match, the validation fails, but there is a possibility to automatically fix it (the prefix gets replaced, the suffix is kept).
