### PR TITLE
Bug fixes for releases

### DIFF
--- a/cernopendata/modules/records/serializers/basic_json.py
+++ b/cernopendata/modules/records/serializers/basic_json.py
@@ -130,7 +130,7 @@ def dump_files(obj):
 class RecordSchemaV1(Schema):
     """Common record schema."""
 
-    id = fields.Integer(attribute="pid.pid_value", dump_only=True)
+    id = fields.Str(attribute="pid.pid_value", dump_only=True)
     created = fields.Str(dump_only=True)
     updated = fields.Str(dump_only=True)
     metadata = fields.Method("dump_metadata")

--- a/cernopendata/modules/records/utils.py
+++ b/cernopendata/modules/records/utils.py
@@ -385,6 +385,9 @@ def export_json_view(pid, record, template=None, **kwargs):
             data = serializer.serialize(pid, record)
             data = json.loads(data)
         except Exception:
+            current_app.logger.exception(
+                "JSON export failed for record {}.".format(str(record.id))
+            )
             data = {}
 
         return jsonify(data)

--- a/cernopendata/modules/releases/validations/missing_files.py
+++ b/cernopendata/modules/releases/validations/missing_files.py
@@ -1,0 +1,26 @@
+"""Missing files validation."""
+
+from .base import Validation
+
+
+class MissingFiles(Validation):
+    """Check that records claiming files actually provide them."""
+
+    name = "Missing files"
+    error_message = "Some records report having files, but none were provided."
+
+    def validate(self, release):
+        """Flag records that report having files but provide none."""
+        errors = []
+        for i, record in enumerate(release.records):
+            number_files = (record.get("distribution") or {}).get("number_files") or 0
+            if (
+                number_files
+                and not record.get("files")
+                and "rucio_dataset" not in record
+            ):
+                errors.append(
+                    f"Entry {i + 1} reports having {number_files} files "
+                    f"but none were provided."
+                )
+        return errors

--- a/tests/releases/test_validator_missing_files.py
+++ b/tests/releases/test_validator_missing_files.py
@@ -1,0 +1,68 @@
+from cernopendata.modules.releases.validations.missing_files import MissingFiles
+
+
+class DummyRelease:
+    def __init__(self, records):
+        self.records = records
+
+
+def test_reports_files_but_none_provided():
+    release = DummyRelease([{"distribution": {"number_files": 423}}])
+
+    errors = MissingFiles().validate(release)
+
+    assert errors == ["Entry 1 reports having 423 files but none were provided."]
+
+
+def test_files_provided():
+    release = DummyRelease(
+        [{"distribution": {"number_files": 1}, "files": [{"uri": "a"}]}]
+    )
+
+    assert MissingFiles().validate(release) == []
+
+
+def test_index_files_count_as_provided():
+    release = DummyRelease(
+        [
+            {
+                "distribution": {"number_files": 1000},
+                "files": [{"uri": "index.json", "type": "index.json"}],
+            }
+        ]
+    )
+
+    assert MissingFiles().validate(release) == []
+
+
+def test_rucio_dataset_is_exempt():
+    release = DummyRelease(
+        [{"distribution": {"number_files": 423}, "rucio_dataset": "cms:/foo/bar"}]
+    )
+
+    assert MissingFiles().validate(release) == []
+
+
+def test_no_distribution():
+    release = DummyRelease([{}])
+
+    assert MissingFiles().validate(release) == []
+
+
+def test_zero_files_declared():
+    release = DummyRelease([{"distribution": {"number_files": 0}}])
+
+    assert MissingFiles().validate(release) == []
+
+
+def test_only_offending_entries_flagged():
+    release = DummyRelease(
+        [
+            {"distribution": {"number_files": 1}, "files": [{"uri": "a"}]},
+            {"distribution": {"number_files": 5}},
+        ]
+    )
+
+    errors = MissingFiles().validate(release)
+
+    assert errors == ["Entry 2 reports having 5 files but none were provided."]


### PR DESCRIPTION
1. **Ensure json export works for records in a release** 
Currently json export feature is broken for records in releases on opendata-dev, [example here](https://opendata-dev.cern.ch/record/atlas-2/export/json).
2. **Add validator to ensure files are provided** 
The bug reported was that files are not rendered when viewing a record in a staged release on opendata-dev, [example here](https://opendata-dev.cern.ch/record/atlas-2). For now, I could not identify whether the cause is files missing from the release or something else. As a partial fix, now it will be ensured that files are provided in a release before staging.