### PR TITLE
Releases table redesign

### DIFF
--- a/cernopendata/modules/releases/views.py
+++ b/cernopendata/modules/releases/views.py
@@ -227,7 +227,7 @@ def release_upload(experiment):
     elif source == "url":
         url = request.form.get("url")
         if not url:
-            abort(400, "Missing URL")
+            return jsonify({"error": "Missing URL"}), 400
 
         try:
             payload = _fetch_json(url)
@@ -236,7 +236,7 @@ def release_upload(experiment):
         source_filename = url.rsplit("/", 1)[-1]
 
     else:
-        abort(400, "Invalid source")
+        return jsonify({"error": "Invalid source"}), 400
 
     records, documents = _split_payload(payload, source_filename)
 
@@ -356,19 +356,18 @@ def update_records(experiment, release_id):
     """Update the records of a release."""
     # Get JSON string from form
 
-    data = request.get_json(silent=True)
-    if not data["records"]:
-        flash("No records provided", "error")
-        abort(400, "No records provided")
+    data = request.get_json(silent=True) or {}
+    records = data.get("records")
+    if not records:
+        return jsonify({"error": "No records provided"}), 400
 
-    if not isinstance(data["records"], list):
-        flash("Records must be a list", "error")
-        abort(400, "Records must be a list")
+    if not isinstance(records, list):
+        return jsonify({"error": "Records must be a list"}), 400
+
     release = _get_release(experiment, release_id, lock=ReleaseStatus.EDITING)
-    release.update_records(data["records"], current_user)
+    release.update_records(records, current_user)
 
-    flash("Records updated successfully.", "success")
-    return redirect(f"/releases/{experiment}/{release_id}")
+    return jsonify({"status": "ok"})
 
 
 @blueprint.route(
@@ -451,7 +450,7 @@ def add_documents(experiment, release_id):
     """Add documents to a release."""
     data = request.get_json(silent=True)
     if not data:
-        abort(400, "Missing request body")
+        return jsonify({"error": "Missing request body"}), 400
 
     release = _get_release(experiment, release_id)
     source = data.get("source", "json")
@@ -459,7 +458,7 @@ def add_documents(experiment, release_id):
     if source == "urls":
         urls = data.get("urls", [])
         if not urls:
-            abort(400, "Missing URLs")
+            return jsonify({"error": "Missing URLs"}), 400
         json_docs = []
         for url in urls:
             clean_url = url.split("?")[0]
@@ -485,7 +484,7 @@ def add_documents(experiment, release_id):
     else:
         docs = data.get("documents")
         if not docs or not isinstance(docs, list):
-            abort(400, "Missing or invalid documents")
+            return jsonify({"error": "Missing or invalid documents"}), 400
 
     for doc in docs:
         content = doc.get("body", {}).get("content", "")
@@ -516,7 +515,7 @@ def add_records(experiment, release_id):
     """Add records to a release."""
     data = request.get_json(silent=True)
     if not data:
-        abort(400, "Missing request body")
+        return jsonify({"error": "Missing request body"}), 400
 
     release = _get_release(experiment, release_id)
     source = data.get("source", "json")
@@ -524,7 +523,7 @@ def add_records(experiment, release_id):
     if source == "url":
         url = data.get("url")
         if not url:
-            abort(400, "Missing URL")
+            return jsonify({"error": "Missing URL"}), 400
         try:
             payload = _fetch_json(url)
         except URLFetchError as e:
@@ -532,11 +531,11 @@ def add_records(experiment, release_id):
     else:
         payload = data.get("records")
         if payload is None:
-            abort(400, "Missing records")
+            return jsonify({"error": "Missing records"}), 400
 
     records = _normalise_payload(payload)
     if not isinstance(records, list):
-        abort(400, "Records must be a list")
+        return jsonify({"error": "Records must be a list"}), 400
 
     release.add_records(records, current_user)
 
@@ -558,13 +557,13 @@ def upload_image(experiment, release_id):
     """Upload one or more images attached to a parent document."""
     parent_slug = request.form.get("parent_slug")
     if not parent_slug:
-        abort(400, "Missing parent_slug")
+        return jsonify({"error": "Missing parent_slug"}), 400
 
     files = [
         image for image in request.files.getlist("images") if image and image.filename
     ]
     if not files:
-        abort(400, "No image files provided")
+        return jsonify({"error": "No image files provided"}), 400
 
     release = _get_release(experiment, release_id)
 
@@ -573,7 +572,10 @@ def upload_image(experiment, release_id):
         None,
     )
     if not parent:
-        abort(400, f"No document with slug '{parent_slug}' in release")
+        return (
+            jsonify({"error": f"No document with slug '{parent_slug}' in release"}),
+            400,
+        )
 
     images_root = Path(current_app.config["CERNOPENDATA_IMAGES_PATH"]).resolve()
     release_dir = (images_root / str(release_id)).resolve()
@@ -581,7 +583,7 @@ def upload_image(experiment, release_id):
     try:
         target_dir.relative_to(release_dir)
     except ValueError:
-        abort(400, "Invalid parent_slug")
+        return jsonify({"error": "Invalid parent_slug"}), 400
     try:
         target_dir.mkdir(parents=True, exist_ok=True)
         already_existing = {p.name for p in target_dir.iterdir()}
@@ -592,7 +594,7 @@ def upload_image(experiment, release_id):
     for file in files:
         filename = secure_filename(file.filename or "").lower()
         if not filename:
-            abort(400, "Invalid filename")
+            return jsonify({"error": "Invalid filename"}), 400
         extension = Path(filename).suffix.lower()
         if extension not in ALLOWED_IMAGE_EXTENSIONS:
             return (
@@ -618,7 +620,7 @@ def upload_image(experiment, release_id):
         try:
             target_path.relative_to(target_dir)
         except ValueError:
-            abort(400, "Invalid filename")
+            return jsonify({"error": "Invalid filename"}), 400
 
         if filename in already_existing:
             return (
@@ -702,7 +704,10 @@ def delete_image(experiment, release_id, parent_slug, filename):
         None,
     )
     if not parent:
-        abort(404, f"No document with slug '{parent_slug}' in release")
+        return (
+            jsonify({"error": f"No document with slug '{parent_slug}' in release"}),
+            404,
+        )
 
     images_root = Path(current_app.config["CERNOPENDATA_IMAGES_PATH"]).resolve()
     release_dir = (images_root / str(release_id)).resolve()
@@ -710,19 +715,19 @@ def delete_image(experiment, release_id, parent_slug, filename):
     try:
         slug_dir.relative_to(release_dir)
     except ValueError:
-        abort(400, "Invalid parent_slug")
+        return jsonify({"error": "Invalid parent_slug"}), 400
 
     safe_filename = secure_filename(filename)
     if not safe_filename:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
     target_path = (slug_dir / safe_filename).resolve()
     try:
         target_path.relative_to(slug_dir)
     except ValueError:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
 
     if not target_path.is_file():
-        abort(404, "Image not found")
+        return jsonify({"error": "Image not found"}), 404
 
     try:
         target_path.unlink()
@@ -750,7 +755,7 @@ def rename_image(experiment, release_id, parent_slug, filename):
     data = request.get_json(silent=True) or {}
     new_filename = data.get("filename")
     if not new_filename:
-        abort(400, "Missing filename")
+        return jsonify({"error": "Missing filename"}), 400
 
     release = _get_release(experiment, release_id)
 
@@ -759,7 +764,10 @@ def rename_image(experiment, release_id, parent_slug, filename):
         None,
     )
     if not parent:
-        abort(404, f"No document with slug '{parent_slug}' in release")
+        return (
+            jsonify({"error": f"No document with slug '{parent_slug}' in release"}),
+            404,
+        )
 
     images_root = Path(current_app.config["CERNOPENDATA_IMAGES_PATH"]).resolve()
     release_dir = (images_root / str(release_id)).resolve()
@@ -767,12 +775,12 @@ def rename_image(experiment, release_id, parent_slug, filename):
     try:
         slug_dir.relative_to(release_dir)
     except ValueError:
-        abort(400, "Invalid parent_slug")
+        return jsonify({"error": "Invalid parent_slug"}), 400
 
     safe_old = secure_filename(filename).lower()
     safe_new = secure_filename(new_filename).lower()
     if not safe_old or not safe_new:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
 
     new_extension = Path(safe_new).suffix.lower()
     if new_extension not in ALLOWED_IMAGE_EXTENSIONS:
@@ -787,10 +795,10 @@ def rename_image(experiment, release_id, parent_slug, filename):
         source_path.relative_to(slug_dir)
         target_path.relative_to(slug_dir)
     except ValueError:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
 
     if not source_path.is_file():
-        abort(404, "Image not found")
+        return jsonify({"error": "Image not found"}), 404
 
     if target_path == source_path:
         return jsonify(
@@ -841,10 +849,10 @@ def update_document(experiment, release_id, slug):
     """Update a document in a release."""
     data = request.get_json(silent=True)
     if not data:
-        abort(400, "Missing request body")
+        return jsonify({"error": "Missing request body"}), 400
     updated_doc = data.get("document")
     if not updated_doc:
-        abort(400, "Missing document data")
+        return jsonify({"error": "Missing document data"}), 400
 
     release = _get_release(experiment, release_id)
     try:
@@ -890,10 +898,10 @@ def bulk_edit_records_apply(experiment, release_id):
         try:
             updates = json.loads(request.form["updates"])
         except ValueError:
-            abort(400, "Invalid JSON in upload")
+            return jsonify({"error": "Invalid JSON in upload"}), 400
 
     if not updates:
-        abort(400, "Missing updates")
+        return jsonify({"error": "Missing updates"}), 400
 
     release = _get_release(experiment, release_id, lock=ReleaseStatus.EDITING)
     diff = release.bulk_update(updates, current_user)
@@ -952,7 +960,7 @@ def preview_record():
     """Preview a record."""
     data = request.json
     if not data or not isinstance(data, dict):
-        abort(400, description="Invalid JSON payload")
+        return jsonify({"error": "Invalid JSON payload"}), 400
     return {
         "html": render_template(
             [
@@ -971,7 +979,7 @@ def preview_document():
     """Preview a document."""
     data = request.json
     if not data or not isinstance(data, dict):
-        abort(400, description="Invalid JSON payload")
+        return jsonify({"error": "Invalid JSON payload"}), 400
     return {
         "html": render_template(
             ["cernopendata_records_ui/docs/detail.html"],

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
@@ -12,7 +12,7 @@ if (container) {
   const experiment = container.dataset.experiment || null;
   ReactDOM.render(<ReleasesTable experiment={experiment} />, container);
 
-  $(".ui.checkbox").checkbox();
+  $("#create-release-modal .ui.checkbox").checkbox();
 
   $("#open-create-release").on("click", () => {
     $("#create-release-modal").modal("show");

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
@@ -115,6 +115,10 @@ $(document).on("click", "#history-button", function () {
   $("#history-modal").modal("show");
 });
 
+$("#delete-release-action").on("click", function () {
+  $("#delete-release-form").submit();
+});
+
 $("#edit-metadata-action").on("click", function () {
   $("#meta-name").val($("#release-name").text() || "");
   $("#meta-link").val($("#release-discussion-url").attr("href") || "");

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
@@ -15,6 +15,9 @@ if (container) {
   $("#create-release-modal .ui.checkbox").checkbox();
 
   $("#open-create-release").on("click", () => {
+    $("#create-release-form")[0].reset();
+    $("#create-release-error").hide().text("");
+    updateSource();
     $("#create-release-modal").modal("show");
   });
 

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleaseContent.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleaseContent.js
@@ -17,6 +17,9 @@ export default function ReleaseContent({
   const showDoiWarning =
     releaseStatus === "STAGED" && records.some((record) => !record.doi);
 
+  const defaultActiveIndex =
+    initialRecords.length === 0 && initialDocuments.length > 0 ? 1 : 0;
+
   const panes = [
     {
       menuItem: { key: "records", icon: "database", content: "Records" },
@@ -65,7 +68,7 @@ export default function ReleaseContent({
           </p>
         </div>
       )}
-      <Tab panes={panes} />
+      <Tab panes={panes} defaultActiveIndex={defaultActiveIndex} />
     </div>
   );
 }

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleasesTable.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleasesTable.js
@@ -1,15 +1,92 @@
-import React, { useEffect, useState } from "react";
-import { Table, Loader, Icon } from "semantic-ui-react";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Checkbox,
+  Dropdown,
+  Icon,
+  Input,
+  Label,
+  Loader,
+  Popup,
+  Table,
+} from "semantic-ui-react";
 
 const statusToStep = {
   EDITING: "DRAFT",
   READY: "DRAFT",
   STAGING: "DRAFT",
+  PUBLISHING: "STAGED",
 };
+
+function stepOf(release) {
+  return statusToStep[release.status] || release.status;
+}
+
+function stepIcon(release) {
+  switch (stepOf(release)) {
+    case "PUBLISHED":
+      return { name: "check circle outline", color: "green" };
+    case "STAGED":
+      return { name: "clock outline", color: "blue" };
+    case "DRAFT":
+      return { name: "circle outline", color: "grey" };
+    default:
+      return { name: "question circle outline", color: "grey" };
+  }
+}
+
+function sortValue(release, field) {
+  switch (field) {
+    case "name":
+      return release.name || "";
+    case "step":
+      return stepOf(release);
+    case "last_update":
+      return release.last_update
+        ? new Date(release.last_update.timestamp).getTime()
+        : null;
+    case "num_records":
+      return release.num_records;
+    case "num_docs":
+      return release.num_docs;
+    default:
+      return null;
+  }
+}
+
+function compareReleases(left, right, field, direction) {
+  const leftValue = sortValue(left, field);
+  const rightValue = sortValue(right, field);
+
+  if (leftValue == null && rightValue == null) return 0;
+  if (leftValue == null) return 1;
+  if (rightValue == null) return -1;
+
+  const order =
+    typeof leftValue === "string"
+      ? leftValue.localeCompare(rightValue)
+      : leftValue - rightValue;
+  return direction === "asc" ? order : -order;
+}
+
+function formatLastUpdate(lastUpdate) {
+  if (!lastUpdate) {
+    return "-";
+  }
+  const when = new Date(lastUpdate.timestamp).toLocaleString();
+  return lastUpdate.user ? `${when} by ${lastUpdate.user}` : when;
+}
+
 export default function ReleasesTable({ experiment }) {
   const [releases, setReleases] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+
+  const [sortField, setSortField] = useState(null);
+  const [sortDirection, setSortDirection] = useState("asc");
+  const [nameFilter, setNameFilter] = useState("");
+  const [stepFilters, setStepFilters] = useState([]);
+  const [showPublished, setShowPublished] = useState(true);
+
   const experiment_lower = experiment.toLowerCase();
   useEffect(() => {
     let url = `/releases/api/list/${experiment_lower}`;
@@ -32,89 +109,227 @@ export default function ReleasesTable({ experiment }) {
       });
   }, []);
 
-  if (loading) {
-    return <Loader active inline="centered" />;
-  }
-  return (
-    <Table celled selectable striped>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell className="no-glossary">ID</Table.HeaderCell>
-          <Table.HeaderCell>Name</Table.HeaderCell>
-          <Table.HeaderCell>Step</Table.HeaderCell>
-          <Table.HeaderCell>Last update</Table.HeaderCell>
-          <Table.HeaderCell>Records</Table.HeaderCell>
-          <Table.HeaderCell>Documents</Table.HeaderCell>
-          <Table.HeaderCell>Discussion</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {error ? (
-          <Table.Row>
-            <Table.Cell colSpan="7" textAlign="center">
-              <Icon name="warning circle" /> Could not load releases.
-            </Table.Cell>
-          </Table.Row>
-        ) : releases.length === 0 ? (
-          <Table.Row>
-            <Table.Cell colSpan="7" textAlign="center">
-              No releases found.
-            </Table.Cell>
-          </Table.Row>
-        ) : (
-          releases.map((r) => (
-            <Table.Row
-              key={r.id}
-              onClick={() => {
-                window.location.href = `/releases/${experiment_lower}/${r.id}`;
-              }}
-              style={{ cursor: "pointer" }}
-              className="hoverable"
-            >
-              <Table.Cell>{r.id}</Table.Cell>
-              <Table.Cell>{r.name}</Table.Cell>
-              <Table.Cell>
-                {statusToStep[r.last_update.status] || r.last_update.status}
-                {r.num_errors > 0 && (
-                  <Icon
-                    name="warning circle"
-                    color="red"
-                    title={`${r.num_errors} error${r.num_errors !== 1 ? "s" : ""}`}
-                    style={{ marginLeft: "0.5em" }}
-                  />
-                )}
-                {r.last_update.status === "PUBLISHED" && (
-                  <Icon
-                    name="check circle outline"
-                    color="green"
-                    style={{ marginLeft: "0.5em" }}
-                  />
-                )}
-                {r.last_update.status === "STAGED" && (
-                  <Icon
-                    name="clock outline"
-                    color="blue"
-                    style={{ marginLeft: "0.5em" }}
-                  />
-                )}
-              </Table.Cell>
-              <Table.Cell>
-                {formatDate(r.last_update.timestamp)} by {r.last_update.user}
-              </Table.Cell>
-              <Table.Cell>{r.num_records}</Table.Cell>
-              <Table.Cell>{r.num_docs}</Table.Cell>
-              <Table.Cell>{r.discussion}</Table.Cell>
-            </Table.Row>
-          ))
-        )}
-      </Table.Body>
-    </Table>
+  const publishFilteredReleases = useMemo(
+    () =>
+      showPublished
+        ? releases
+        : releases.filter((release) => stepOf(release) !== "PUBLISHED"),
+    [releases, showPublished],
   );
-}
 
-function formatDate(value) {
-  if (!value) {
-    return "–";
-  }
-  return new Date(value).toLocaleString();
+  const stepOptions = useMemo(() => {
+    const steps = [...new Set(publishFilteredReleases.map(stepOf))];
+    return steps.map((step) => ({ key: step, text: step, value: step }));
+  }, [publishFilteredReleases]);
+
+  const visibleReleases = useMemo(() => {
+    const normalizedNameFilter = nameFilter.trim().toLowerCase();
+    const filtered = publishFilteredReleases.filter((release) => {
+      const matchesName =
+        !normalizedNameFilter ||
+        (release.name || "").toLowerCase().includes(normalizedNameFilter);
+      const matchesStep =
+        stepFilters.length === 0 || stepFilters.includes(stepOf(release));
+      return matchesName && matchesStep;
+    });
+
+    if (!sortField) {
+      return filtered;
+    }
+    return [...filtered].sort((left, right) =>
+      compareReleases(left, right, sortField, sortDirection),
+    );
+  }, [
+    publishFilteredReleases,
+    nameFilter,
+    stepFilters,
+    sortField,
+    sortDirection,
+  ]);
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDirection("asc");
+    }
+  };
+
+  const sortedProp = (field) => {
+    if (sortField !== field) {
+      return null;
+    }
+    return sortDirection === "asc" ? "ascending" : "descending";
+  };
+
+  return (
+    <>
+      {loading ? (
+        <Loader active inline="centered" />
+      ) : (
+        <Table
+          celled
+          selectable
+          striped
+          sortable
+          size="small"
+          className="hoverable-row-table releases-table"
+        >
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell
+                sorted={sortedProp("name")}
+                onClick={() => handleSort("name")}
+              >
+                Name
+              </Table.HeaderCell>
+              <Table.HeaderCell
+                sorted={sortedProp("step")}
+                onClick={() => handleSort("step")}
+              >
+                Step
+              </Table.HeaderCell>
+              <Table.HeaderCell
+                rowSpan="2"
+                sorted={sortedProp("last_update")}
+                onClick={() => handleSort("last_update")}
+              >
+                Last update
+              </Table.HeaderCell>
+              <Table.HeaderCell
+                rowSpan="2"
+                className="col-count"
+                sorted={sortedProp("num_records")}
+                onClick={() => handleSort("num_records")}
+              >
+                Records
+              </Table.HeaderCell>
+              <Table.HeaderCell
+                rowSpan="2"
+                className="col-count"
+                sorted={sortedProp("num_docs")}
+                onClick={() => handleSort("num_docs")}
+              >
+                Documents
+              </Table.HeaderCell>
+              <Table.HeaderCell rowSpan="2" className="discussion-column">
+                Discussion
+              </Table.HeaderCell>
+            </Table.Row>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Input
+                  fluid
+                  icon="search"
+                  iconPosition="left"
+                  placeholder="Filter by name"
+                  value={nameFilter}
+                  onChange={(_, data) => setNameFilter(data.value)}
+                />
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Dropdown
+                  selection
+                  multiple
+                  search
+                  fluid
+                  placeholder="Filter by step"
+                  options={stepOptions}
+                  value={stepFilters}
+                  onChange={(_, data) => setStepFilters(data.value)}
+                />
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {error ? (
+              <Table.Row>
+                <Table.Cell colSpan="6" textAlign="center">
+                  <Icon name="warning circle" /> Could not load releases.
+                </Table.Cell>
+              </Table.Row>
+            ) : visibleReleases.length === 0 ? (
+              <Table.Row>
+                <Table.Cell colSpan="6" textAlign="center">
+                  No releases found.
+                </Table.Cell>
+              </Table.Row>
+            ) : (
+              visibleReleases.map((release) => (
+                <Table.Row
+                  key={release.id}
+                  onClick={() => {
+                    window.location.href = `/releases/${experiment_lower}/${release.id}`;
+                  }}
+                  style={{ cursor: "pointer" }}
+                >
+                  <Table.Cell>{release.name}</Table.Cell>
+                  <Table.Cell>
+                    <div className="release-step">
+                      <span className="release-step-icon">
+                        <Icon {...stepIcon(release)} />
+                      </span>
+                      {stepOf(release)}
+                      {release.num_errors > 0 && (
+                        <Popup
+                          size="tiny"
+                          position="top center"
+                          content={`${release.num_errors} error${release.num_errors !== 1 ? "s" : ""}`}
+                          trigger={
+                            <Label circular color="red" size="tiny">
+                              {release.num_errors}
+                            </Label>
+                          }
+                        />
+                      )}
+                    </div>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {formatLastUpdate(release.last_update)}
+                  </Table.Cell>
+                  <Table.Cell>{release.num_records}</Table.Cell>
+                  <Table.Cell>{release.num_docs}</Table.Cell>
+                  <Table.Cell textAlign="center" className="discussion-column">
+                    {release.discussion && (
+                      <a
+                        href={release.discussion}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <Icon name="linkify" />
+                        Open discussion
+                      </a>
+                    )}
+                  </Table.Cell>
+                </Table.Row>
+              ))
+            )}
+          </Table.Body>
+          {!error && (
+            <Table.Footer>
+              <Table.Row>
+                <Table.HeaderCell colSpan="6">
+                  <div className="releases-table-footer">
+                    <span>
+                      {visibleReleases.length === releases.length
+                        ? `Showing ${releases.length} releases`
+                        : `Showing ${visibleReleases.length} of ${releases.length} releases`}
+                    </span>
+                    <Checkbox
+                      className="show-published-filter"
+                      label="Show published releases"
+                      checked={showPublished}
+                      onChange={(_, data) => setShowPublished(data.checked)}
+                    />
+                  </div>
+                </Table.HeaderCell>
+              </Table.Row>
+            </Table.Footer>
+          )}
+        </Table>
+      )}
+    </>
+  );
 }

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/DocumentsTable.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/DocumentsTable.js
@@ -5,7 +5,7 @@ import EditDocumentModal from "./EditDocumentModal";
 import UploadImagesModal from "./UploadImagesModal";
 import EditImageModal from "./EditImageModal";
 import PreviewImageModal from "./PreviewImageModal";
-import usePagination from "../shared/usePagination";
+import { usePagination } from "../shared/utils";
 import RowActions from "../shared/RowActions";
 
 export default function DocumentsTable({

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, TextArea, Tab, Button, Icon } from "semantic-ui-react";
+import {
+  Modal,
+  Form,
+  TextArea,
+  Tab,
+  Button,
+  Icon,
+  Message,
+} from "semantic-ui-react";
 import PreviewTab from "../shared/PreviewTab";
+import { fetchJson } from "../shared/utils";
 
 export default function EditDocumentModal({
   doc,
@@ -11,6 +20,7 @@ export default function EditDocumentModal({
 }) {
   const [metaDataBuffer, setMetaDataBuffer] = useState("");
   const [bodyBuffer, setBodyBuffer] = useState("");
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!doc) return;
@@ -22,14 +32,17 @@ export default function EditDocumentModal({
     }
     setMetaDataBuffer(JSON.stringify(metaData, null, 2));
     setBodyBuffer(body?.content || "");
+    setError(null);
   }, [doc]);
 
   const handleSave = async () => {
+    setError(null);
+
     let updated;
     try {
       updated = JSON.parse(metaDataBuffer);
     } catch (e) {
-      alert("Invalid JSON: " + e.message);
+      setError("Invalid JSON: " + e.message);
       return;
     }
     updated.body = {
@@ -39,7 +52,7 @@ export default function EditDocumentModal({
     };
 
     try {
-      const response = await fetch(
+      await fetchJson(
         `/releases/${experiment}/${releaseId}/documents/${doc.slug}`,
         {
           method: "PUT",
@@ -47,13 +60,8 @@ export default function EditDocumentModal({
           body: JSON.stringify({ document: updated }),
         },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        alert("Failed to save: " + (err.error || response.statusText));
-        return;
-      }
     } catch (e) {
-      alert("Failed to save: " + e.message);
+      setError(e.message);
       return;
     }
 
@@ -77,6 +85,11 @@ export default function EditDocumentModal({
     <Modal open={!!doc} onClose={onClose} closeIcon size="large">
       <Modal.Header>Edit Document</Modal.Header>
       <Modal.Content scrolling>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Form>
           <Tab
             panes={[

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
@@ -83,7 +83,9 @@ export default function EditDocumentModal({
 
   return (
     <Modal open={!!doc} onClose={onClose} closeIcon size="large">
-      <Modal.Header>Edit Document</Modal.Header>
+      <Modal.Header>
+        {doc?.slug ? `Edit document ${doc.slug}` : "Edit document"}
+      </Modal.Header>
       <Modal.Content scrolling>
         {error && (
           <Message negative>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
@@ -55,7 +55,7 @@ export default function EditImageModal({
 
   return (
     <Modal open={!!image} onClose={onClose} closeIcon size="small">
-      <Modal.Header>Edit Image</Modal.Header>
+      <Modal.Header>Edit image</Modal.Header>
       <Modal.Content>
         {error && (
           <Message negative>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Input, Button, Icon } from "semantic-ui-react";
+import { Modal, Form, Input, Button, Icon, Message } from "semantic-ui-react";
+import { fetchJson } from "../shared/utils";
 
 export default function EditImageModal({
   image,
@@ -10,35 +11,34 @@ export default function EditImageModal({
   onDeleted,
 }) {
   const [name, setName] = useState("");
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (image) setName(image.filename);
+    setError(null);
   }, [image]);
 
   const handleDelete = async () => {
     if (!window.confirm(`Delete ${image.filename}?`)) return;
+    setError(null);
     try {
-      const response = await fetch(
+      await fetchJson(
         `/releases/${experiment}/${releaseId}/images/${image.parent_slug}/${image.filename}`,
         { method: "DELETE" },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        alert("Failed to delete: " + (err.error || response.statusText));
-        return;
-      }
       onDeleted(image);
       onClose();
     } catch (e) {
-      alert("Failed to delete: " + e.message);
+      setError(e.message);
     }
   };
 
   const handleRename = async () => {
     const newName = name.trim();
     if (!newName || newName === image.filename) return;
+    setError(null);
     try {
-      const response = await fetch(
+      const result = await fetchJson(
         `/releases/${experiment}/${releaseId}/images/${image.parent_slug}/${image.filename}`,
         {
           method: "PUT",
@@ -46,16 +46,10 @@ export default function EditImageModal({
           body: JSON.stringify({ filename: newName }),
         },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        alert("Failed to rename: " + (err.error || response.statusText));
-        return;
-      }
-      const result = await response.json();
       onRenamed(image, result.image);
       onClose();
     } catch (e) {
-      alert("Failed to rename: " + e.message);
+      setError(e.message);
     }
   };
 
@@ -63,6 +57,11 @@ export default function EditImageModal({
     <Modal open={!!image} onClose={onClose} closeIcon size="small">
       <Modal.Header>Edit Image</Modal.Header>
       <Modal.Content>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Form>
           <Form.Field>
             <label htmlFor="image-edit-name">Filename</label>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/UploadImagesModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/UploadImagesModal.js
@@ -7,6 +7,7 @@ import {
   Button,
   Icon,
 } from "semantic-ui-react";
+import { fetchJson } from "../shared/utils";
 
 export default function UploadImagesModal({
   open,
@@ -52,17 +53,10 @@ export default function UploadImagesModal({
         formData.append("images", file);
       }
 
-      const response = await fetch(
+      const result = await fetchJson(
         `/releases/${experiment}/${releaseId}/upload_image`,
         { method: "POST", body: formData },
       );
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || "Failed to upload images");
-      }
-
-      const result = await response.json();
       onUploaded(result.images || []);
       onClose();
     } catch (e) {
@@ -112,7 +106,11 @@ export default function UploadImagesModal({
               }
             />
           </Form.Field>
-          {error && <Message negative>{error}</Message>}
+          {error && (
+            <Message negative>
+              <Icon name="warning circle" /> {error}
+            </Message>
+          )}
         </Form>
       </Modal.Content>
       <Modal.Actions>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/BulkEditModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/BulkEditModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Table, Button, Icon } from "semantic-ui-react";
+import { Modal, Form, Table, Button, Icon, Message } from "semantic-ui-react";
+import { fetchJson } from "../shared/utils";
 
 function DiffObject({ diff }) {
   return (
@@ -67,12 +68,14 @@ export default function BulkEditModal({
   const [bulkActions, setBulkActions] = useState([]);
   const [bulkPreview, setBulkPreview] = useState([]);
   const [bulkPreviewDone, setBulkPreviewDone] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!open) return;
     setBulkActions([]);
     setBulkPreview([]);
     setBulkPreviewDone(false);
+    setError(null);
   }, [open]);
 
   function addBulkRow() {
@@ -120,68 +123,68 @@ export default function BulkEditModal({
 
   async function previewBulk() {
     if (bulkActions.length === 0) return;
+    setError(null);
 
     let updates;
     try {
       updates = collectBulkOperations();
     } catch (e) {
-      alert(e.message);
+      setError(e.message);
       return;
     }
 
-    const res = await fetch(
-      `/releases/${experiment}/${releaseId}/bulk_records/preview`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ updates }),
-      },
-    );
-
-    if (!res.ok) {
-      const json = await res.json().catch(() => ({}));
-      alert(json.error || "Preview failed");
-      return;
+    try {
+      const data = await fetchJson(
+        `/releases/${experiment}/${releaseId}/bulk_records/preview`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates }),
+        },
+      );
+      setBulkPreview(data.diffs || []);
+      setBulkPreviewDone(true);
+    } catch (e) {
+      setError(e.message);
     }
-
-    const data = await res.json();
-    setBulkPreview(data.diffs || []);
-    setBulkPreviewDone(true);
   }
 
   async function applyBulk() {
     if (!bulkPreviewDone) return;
+    setError(null);
 
     let updates;
     try {
       updates = collectBulkOperations();
     } catch (e) {
-      alert(e.message);
+      setError(e.message);
       return;
     }
 
-    const res = await fetch(
-      `/releases/${experiment}/${releaseId}/bulk_records/apply`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ updates }),
-      },
-    );
-
-    if (!res.ok) {
-      const json = await res.json().catch(() => ({}));
-      alert(json.error || "Apply failed");
-      return;
+    try {
+      await fetchJson(
+        `/releases/${experiment}/${releaseId}/bulk_records/apply`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates }),
+        },
+      );
+      window.location.reload();
+    } catch (e) {
+      setError(e.message);
     }
-
-    window.location.reload();
   }
 
   return (
     <Modal open={open} onClose={onClose} closeIcon size="fullscreen">
       <Modal.Header>Bulk edit records</Modal.Header>
       <Modal.Content>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Form>
           <Table celled compact size="small">
             <thead>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
@@ -201,7 +201,7 @@ export default function EditRecordModal({
       <Modal.Actions>
         <Button onClick={onClose}>Cancel</Button>
         <Button primary onClick={handleSave}>
-          Save
+          <Icon name="save" /> Save
         </Button>
       </Modal.Actions>
     </Modal>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
@@ -1,9 +1,18 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { Modal, Form, TextArea, Tab, Button, Message } from "semantic-ui-react";
+import {
+  Modal,
+  Form,
+  TextArea,
+  Tab,
+  Button,
+  Message,
+  Icon,
+} from "semantic-ui-react";
 import { AutoForm } from "uniforms-semantic";
 import PreviewTab from "../shared/PreviewTab";
 import SchemaNode from "./SchemaNode";
 import createBridge from "./schema";
+import { fetchJson } from "../shared/utils";
 
 export default function EditRecordModal({
   editingRecord,
@@ -19,6 +28,12 @@ export default function EditRecordModal({
   const [bridge, setBridge] = useState(null);
   const [origSchema, setOrigSchema] = useState(null);
   const [schemaError, setSchemaError] = useState(false);
+  const [error, setError] = useState(null);
+
+  const open = !!editingRecord || editAllMode;
+  useEffect(() => {
+    if (open) setError(null);
+  }, [open]);
 
   useEffect(() => {
     fetch("/schema/records/record-v1.0.0.json")
@@ -136,52 +151,51 @@ export default function EditRecordModal({
     },
   ];
 
-  const handleSave = () => {
-    const updatedRecords = editAllMode
-      ? records
-      : (() => {
-          if (
-            editingIndex == null ||
-            editingIndex < 0 ||
-            editingIndex >= records.length
-          ) {
-            alert("Record not found");
-            return records;
-          }
-          const copy = [...records];
-          copy[editingIndex] = editingRecord;
-          return copy;
-        })();
+  const handleSave = async () => {
+    setError(null);
 
-    fetch(`/releases/${experiment}/${releaseId}/update_records`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ records: updatedRecords }),
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          const json = await response.json().catch(() => ({}));
-          throw new Error(json.error || "Save failed");
-        }
-        setRecords(updatedRecords);
-        onClose();
-      })
-      .catch((err) => alert(err.message));
+    let updatedRecords;
+    if (editAllMode) {
+      updatedRecords = records;
+    } else {
+      if (
+        editingIndex == null ||
+        editingIndex < 0 ||
+        editingIndex >= records.length
+      ) {
+        setError("Record not found.");
+        return;
+      }
+      updatedRecords = [...records];
+      updatedRecords[editingIndex] = editingRecord;
+    }
+
+    try {
+      await fetchJson(`/releases/${experiment}/${releaseId}/update_records`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ records: updatedRecords }),
+      });
+      setRecords(updatedRecords);
+      onClose();
+    } catch (e) {
+      setError(e.message);
+    }
   };
 
   return (
-    <Modal
-      open={!!editingRecord || editAllMode}
-      onClose={onClose}
-      closeIcon
-      size="fullscreen"
-    >
+    <Modal open={open} onClose={onClose} closeIcon size="fullscreen">
       <Modal.Header>
         {editAllMode
           ? "Edit all records"
           : `Edit record ${editingRecord?.recid}`}
       </Modal.Header>
       <Modal.Content>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Tab panes={panes} />
       </Modal.Content>
       <Modal.Actions>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/RecordsTable.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/RecordsTable.js
@@ -1,10 +1,17 @@
 import React, { useEffect, useState, useRef } from "react";
-import { Table, Button, Icon, Pagination, Popup } from "semantic-ui-react";
+import {
+  Table,
+  Button,
+  Icon,
+  Pagination,
+  Popup,
+  Message,
+} from "semantic-ui-react";
 import EditRecordModal from "./EditRecordModal";
 import BulkEditModal from "./BulkEditModal";
 import AddItemsModal from "../shared/AddItemsModal";
-import usePagination from "../shared/usePagination";
 import RowActions from "../shared/RowActions";
+import { fetchJson, usePagination } from "../shared/utils";
 
 export default function RecordsTable({
   experiment,
@@ -30,17 +37,19 @@ export default function RecordsTable({
   const [bulkModalOpen, setBulkModalOpen] = useState(false);
   const [doiLoading, setDoiLoading] = useState(false);
   const [doiErrors, setDoiErrors] = useState([]);
+  const [error, setError] = useState(null);
 
   const allHaveDoi =
     records.length > 0 && records.every((record) => record.doi);
 
   async function handleGenerateDoi() {
     setDoiLoading(true);
+    setError(null);
     const recidsWithoutDoi = records
       .filter((record) => !record.doi)
       .map((record) => record.recid);
     try {
-      const response = await fetch(
+      const data = await fetchJson(
         `/releases/${experiment}/${releaseId}/generate_doi`,
         {
           method: "POST",
@@ -48,15 +57,10 @@ export default function RecordsTable({
           body: JSON.stringify({ recids: recidsWithoutDoi }),
         },
       );
-      if (!response.ok) {
-        const json = await response.json().catch(() => ({}));
-        throw new Error(json.error || "Request failed");
-      }
-      const data = await response.json();
       setRecords(data.records);
       setDoiErrors(data.errors || []);
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     } finally {
       setDoiLoading(false);
     }
@@ -84,6 +88,11 @@ export default function RecordsTable({
 
   return (
     <>
+      {error && (
+        <Message negative>
+          <Icon name="warning circle" /> {error}
+        </Message>
+      )}
       {doiErrors.length > 0 && (
         <div className="ui segment validation-segment">
           <div className="validation-header">
@@ -94,9 +103,9 @@ export default function RecordsTable({
               <span className="ui red label">{doiErrors.length} failed</span>
             </div>
           </div>
-          {doiErrors.map((error, index) => (
+          {doiErrors.map((validationError, index) => (
             <div
-              key={error.recid}
+              key={validationError.recid}
               className={`validation-row${index < doiErrors.length - 1 ? " validation-row-bordered" : ""}`}
             >
               <div className="validation-row-icon">
@@ -104,7 +113,7 @@ export default function RecordsTable({
               </div>
               <div className="validation-row-body">
                 <b>
-                  recid {error.recid}: {error.error}
+                  recid {validationError.recid}: {validationError.error}
                 </b>
               </div>
             </div>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/AddItemsModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/AddItemsModal.js
@@ -12,6 +12,7 @@ import {
   rewriteDocLinks,
   slugFromFilename,
 } from "../documents/rewriteDocLinks";
+import { fetchJson } from "./utils";
 
 const CONFIG = {
   documents: {
@@ -132,7 +133,7 @@ export default function AddItemsModal({
     setLoading(true);
     try {
       const requestBody = await buildRequestBody();
-      const response = await fetch(
+      const result = await fetchJson(
         `/releases/${experiment}/${releaseId}/${endpoint}`,
         {
           method: "POST",
@@ -140,11 +141,6 @@ export default function AddItemsModal({
           body: JSON.stringify(requestBody),
         },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || `Failed to save ${collection}`);
-      }
-      const result = await response.json();
       onAdded(result[collection] || []);
       onClose();
     } catch (e) {
@@ -279,7 +275,11 @@ export default function AddItemsModal({
             </Form.Field>
           )}
 
-          {error && <Message negative>{error}</Message>}
+          {error && (
+            <Message negative>
+              <Icon name="warning circle" /> {error}
+            </Message>
+          )}
         </Form>
       </Modal.Content>
       <Modal.Actions>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/PreviewTab.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/PreviewTab.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Loader, Message } from "semantic-ui-react";
+import { Loader, Message, Icon } from "semantic-ui-react";
 
 export default function PreviewTab({ endpoint, data }) {
   const [html, setHtml] = useState("");
@@ -52,7 +52,11 @@ export default function PreviewTab({ endpoint, data }) {
   return (
     <div>
       {loading && <Loader active inline="centered" />}
-      {error && <Message negative>{error}</Message>}
+      {error && (
+        <Message negative>
+          <Icon name="warning circle" /> {error}
+        </Message>
+      )}
       <div
         style={{ marginTop: 10 }}
         dangerouslySetInnerHTML={{ __html: html }}

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/usePagination.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/usePagination.js
@@ -1,8 +1,0 @@
-import { useState } from "react";
-
-export default function usePagination(items, pageSize = 5) {
-  const [page, setPage] = useState(0);
-  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
-  const visible = items.slice(page * pageSize, (page + 1) * pageSize);
-  return { page, setPage, visible, totalPages };
-}

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/utils.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/utils.js
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+export async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || `Request failed (${response.status})`);
+  }
+  return response.json();
+}
+
+export function usePagination(items, pageSize = 5) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const visible = items.slice(page * pageSize, (page + 1) * pageSize);
+  return { page, setPage, visible, totalPages };
+}

--- a/cernopendata/modules/theme/assets/semantic-ui/less/cernopendata/site/globals/site.overrides
+++ b/cernopendata/modules/theme/assets/semantic-ui/less/cernopendata/site/globals/site.overrides
@@ -25,7 +25,7 @@
  */
 
 
-a:hover {
+a:hover:not(.icon, :has(> img), :has(> .icon)) {
     border-bottom: 1px solid currentColor;
 }
 

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -588,6 +588,10 @@ a {
     line-height: 1.3;
 }
 
+.ui.dropdown .menu > .release-delete-item:not(.disabled) {
+    color: #db2828 !important;
+}
+
 .release-summary-segment {
     padding: 1.5em 2em;
 

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -557,6 +557,16 @@ a {
   min-width: 150px !important;
 }
 
+.hoverable-row-table .ui.dropdown > .default.text {
+  font-weight: normal;
+}
+
+.hoverable-row-table .ui.multiple.selection.dropdown > .label {
+  margin: 0 0.35em 0 0;
+  padding: 0.3em 0.6em;
+  font-size: 0.85em;
+}
+
 // Release view
 
 .release-page-header-title-row {
@@ -576,15 +586,6 @@ a {
     font-weight: 700;
     margin: 0;
     line-height: 1.3;
-
-    a {
-        color: inherit;
-        text-decoration: none;
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
 }
 
 .release-summary-segment {
@@ -753,11 +754,64 @@ a {
     gap: 0.75em;
 }
 
-.ui.button.create-release-btn {
-   margin: 10px;
+.releases-page {
+    padding-top: 3.5em;
+    padding-bottom: 3em;
 }
 
-.releases-div {
-   margin-top: 10px;
-   margin-bottom: 16px;
+.releases-page-header {
+    margin-bottom: 1.5em;
+
+    .sub.header {
+        margin-top: 0.4em;
+    }
+}
+
+.releases-table-actions {
+    margin-bottom: 0.75em;
+    text-align: right;
+
+    .ui.button {
+        margin-right: 0;
+    }
+}
+
+.releases-table {
+    table-layout: fixed;
+
+    .release-step {
+        display: flex;
+        align-items: center;
+
+        .release-step-icon {
+            flex: 0 0 1.75em;
+        }
+
+        .ui.label {
+            margin-left: auto;
+            margin-right: 0;
+        }
+    }
+
+    .releases-table-footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .show-published-filter {
+        font-weight: normal;
+    }
+
+    th.col-count {
+        width: 8em;
+    }
+
+    .discussion-column {
+        width: 12em;
+
+        a:hover {
+            text-decoration: underline;
+        }
+    }
 }

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -744,9 +744,18 @@ a {
 
 .validation-row-actions {
     flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
+    display: grid;
+    column-gap: 1.5em;
+}
+
+.validation-segment:has(.validation-row-actions > .ui.label) {
+    .validation-row-actions {
+        grid-template-columns: 7.5em 7em;
+
+        > .ui.label {
+            grid-column: 2;
+        }
+    }
 }
 
 .validation-autofix-message {

--- a/cernopendata/templates/cernopendata_pages/release_details/_summary.html
+++ b/cernopendata/templates/cernopendata_pages/release_details/_summary.html
@@ -64,7 +64,7 @@
     <i class="close icon"></i>
 
     <div class="header">
-        Release History
+        Release history
     </div>
 
     <div class="scrolling content">
@@ -120,6 +120,9 @@
 
     <div class="actions">
         <div class="ui cancel button">Cancel</div>
-        <div class="ui primary button" id="save-metadata">Save</div>
+        <div class="ui primary button" id="save-metadata">
+            <i class="save icon"></i>
+            Save
+        </div>
     </div>
 </div>

--- a/cernopendata/templates/cernopendata_pages/release_details/_summary.html
+++ b/cernopendata/templates/cernopendata_pages/release_details/_summary.html
@@ -29,15 +29,12 @@
                 <div class="item" id="edit-metadata-action">
                     Edit metadata
                 </div>
-                <div>
-                    <form action="/releases/{{ release._metadata.experiment }}/{{ release._metadata.id }}/delete"
-                          method="POST">
-                        <button class="ui red button {% if release._metadata.status not in ['READY', 'DRAFT'] %}disabled{% endif %}"
-                                {% if release._metadata.status not in ['READY', 'DRAFT'] %}disabled{% endif %} type="submit">
-                            Delete release
-                        </button>
-                    </form>
+                <div class="item release-delete-item {% if release._metadata.status not in ['READY', 'DRAFT'] %}disabled{% endif %}"
+                     id="delete-release-action">
+                    <b>Delete release</b>
                 </div>
+                <form id="delete-release-form" method="POST"
+                      action="/releases/{{ release._metadata.experiment }}/{{ release._metadata.id }}/delete"></form>
             </div>
         </div>
     </div>

--- a/cernopendata/templates/cernopendata_pages/release_details/_summary.html
+++ b/cernopendata/templates/cernopendata_pages/release_details/_summary.html
@@ -6,15 +6,16 @@
             Back to releases
         </a>
         <h1 class="release-page-title">
-            {% if release._metadata.discussion_url %}
-            <a href="{{ release._metadata.discussion_url }}" id="release-discussion-url" rel="noopener noreferrer" target="_blank">
-                <span id="release-name">{{ release._metadata.name }}</span>
-            </a>
-            {% else %}
             <span id="release-name">{{ release._metadata.name }}</span>
-            {% endif %}
             <span class="ui small blue label">{{ experiment|upper }}</span>
         </h1>
+        {% if release._metadata.discussion_url %}
+        <a href="{{ release._metadata.discussion_url }}" id="release-discussion-url"
+           rel="noopener noreferrer" target="_blank"
+           class="ui small basic button">
+            <i class="linkify icon"></i> Open discussion
+        </a>
+        {% endif %}
         <div class="ui dropdown icon button">
             <i class="ellipsis vertical icon"></i>
             <div class="menu">

--- a/cernopendata/templates/cernopendata_pages/releases.html
+++ b/cernopendata/templates/cernopendata_pages/releases.html
@@ -80,6 +80,7 @@
                         id="uploadButton"
                         class="ui primary button disabled"
                         type="submit">
+                    <i class="plus icon"></i>
                     Create release
                 </button>
             </form>

--- a/cernopendata/templates/cernopendata_pages/releases.html
+++ b/cernopendata/templates/cernopendata_pages/releases.html
@@ -7,95 +7,82 @@
 
 
 {%- block page_body %}
-<div class="ui container releases-div">
-    <div class="ui center aligned segment">
+<div class="ui container releases-page">
 
-        <h2 class="ui header">
-            Welcome to the {{ experiment|upper }} releases
+    <div class="releases-page-header">
+        <h2 class="ui center aligned header">
+            {{ experiment|upper }} releases
+            <div class="sub header">
+                Register new records and documents for {{ experiment|upper }}
+            </div>
         </h2>
+    </div>
 
-        <div class="ui divider"></div>
-            <p>
-                This page allows you to register new records or documents in the repository.
-                <br>
-                You will only be able to register them for
-                <strong>{{ experiment }}</strong>.
-            </p>
+    <div class="releases-table-actions">
+        <button id="open-create-release" class="ui primary button">
+            <i class="plus icon"></i>
+            Create new release
+        </button>
+    </div>
 
-        <div class="ui container">
-            <div class="ui container">
-                <div class="ui grid">
-                    <div class="twelve wide column">
+    <div id="releases-react-root" data-experiment="{{ experiment }}"></div>
+
+    <div id="create-release-modal" class="ui modal">
+        <i class="close icon"></i>
+
+        <div class="header">
+            Create a new release
+        </div>
+
+        <div class="content">
+            <form
+                    id="create-release-form"
+                    class="ui form no-glossary"
+                    method="post"
+                    enctype="multipart/form-data"
+            >
+
+                <div class="grouped fields">
+                    <label>Release source</label>
+
+                    <div class="field">
+                        <div class="ui radio checkbox">
+                            <input type="radio" name="source" value="file" checked>
+                            <label>Upload JSON file</label>
+                        </div>
                     </div>
-                    <div class="four wide column right aligned">
-                        <button id="open-create-release"
-                                class="ui primary button create-release-btn">
-                            <i class="plus icon"></i>
-                            Create new release
-                        </button>
+
+                    <div class="field">
+                        <div class="ui radio checkbox">
+                            <input type="radio" name="source" value="url">
+                            <label>Load from URL</label>
+                        </div>
                     </div>
                 </div>
 
-                <div id="releases-react-root" data-experiment="{{ experiment }}"></div>
-            </div>
-        </div>
-        <div id="create-release-modal" class="ui modal">
-            <i class="close icon"></i>
+                <div class="field" id="file-source">
+                    <label>Release JSON file</label>
+                    <input type="file"
+                           name="file"
+                           accept=".json">
+                </div>
 
-            <div class="header">
-                Create a new release
-            </div>
+                <div class="field" id="url-source" style="display:none">
+                    <label>Release JSON URL</label>
+                    <input type="url"
+                           name="url"
+                           placeholder="https://raw.githubusercontent.com/...">
+                </div>
 
-            <div class="content">
-                <form
-                        id="create-release-form"
-                        class="ui form no-glossary"
-                        method="post"
-                        enctype="multipart/form-data"
-                >
+                <div id="create-release-error" class="ui error message" style="display:none"></div>
 
-                    <div class="grouped fields">
-                        <label>Release source</label>
-
-                        <div class="field">
-                            <div class="ui radio checkbox">
-                                <input type="radio" name="source" value="file" checked>
-                                <label>Upload JSON file</label>
-                            </div>
-                        </div>
-
-                        <div class="field">
-                            <div class="ui radio checkbox">
-                                <input type="radio" name="source" value="url">
-                                <label>Load from URL</label>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="field" id="file-source">
-                        <label>Release JSON file</label>
-                        <input type="file"
-                               name="file"
-                               accept=".json">
-                    </div>
-
-                    <div class="field" id="url-source" style="display:none">
-                        <label>Release JSON URL</label>
-                        <input type="url"
-                               name="url"
-                               placeholder="https://raw.githubusercontent.com/...">
-                    </div>
-
-                    <div id="create-release-error" class="ui error message" style="display:none"></div>
-
-                    <button
-                            id="uploadButton"
-                            class="ui primary button disabled"
-                            type="submit">
-                        Create release
-                    </button>
-                </form>
-            </div>
+                <button
+                        id="uploadButton"
+                        class="ui primary button disabled"
+                        type="submit">
+                    Create release
+                </button>
+            </form>
         </div>
     </div>
 </div>

--- a/tests/releases/test_views.py
+++ b/tests/releases/test_views.py
@@ -51,22 +51,35 @@ def test_invalid_experiment(client):
     assert resp.status_code in (403, 404)
 
 
-def test_upload_url(client, monkeypatch):
-    class FakeResp:
-        def json(self):
-            return {"x": 1}
+@patch("cernopendata.modules.releases.views.Release.create")
+@patch("cernopendata.modules.releases.views.curator_experiments")
+@patch("cernopendata.modules.releases.views.Release.validate_experiment")
+def test_upload_url(
+    mock_validate_exp, mock_curator_exps, mock_create, logged_in_client, monkeypatch
+):
+    mock_validate_exp.return_value = True
+    mock_curator_exps.return_value = {"curator_experiments": ["cms"]}
+    mock_create.return_value = MagicMock(_metadata=MagicMock(id=99))
 
-        def raise_for_status(self):
-            return None
+    records = [{"recid": 1, "experiment": "CMS", "files": []}]
+    monkeypatch.setattr(
+        views.requests,
+        "get",
+        lambda *a, **k: MagicMock(
+            json=lambda: {"records": records},
+            raise_for_status=lambda: None,
+        ),
+    )
 
-    monkeypatch.setattr(views.requests, "get", lambda *a, **k: FakeResp())
-
-    resp = client.post(
+    resp = logged_in_client.post(
         "/releases/cms",
         data={"source": "url", "url": "http://example.com/file.json"},
     )
 
-    assert resp.status_code == 302
+    assert resp.status_code == 200
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("records") == records
+    assert kwargs.get("name") == "file.json"
 
 
 @patch("cernopendata.modules.releases.views._get_release")
@@ -454,6 +467,38 @@ def test_stage_release_dispatches_task(
     assert resp.status_code == 302
     mock_stage_release.delay.assert_called_once()
     mock_release.stage.assert_not_called()
+
+
+@patch("cernopendata.modules.releases.views._get_release")
+def test_update_records_success(mock_get_release, logged_in_client):
+    mock_release = MagicMock()
+    mock_get_release.return_value = mock_release
+
+    resp = logged_in_client.post(
+        "/releases/cms/1/update_records",
+        json={"records": [{"recid": 1}, {"recid": 2}]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+    mock_release.update_records.assert_called_once()
+    updated = mock_release.update_records.call_args[0][0]
+    assert updated == [{"recid": 1}, {"recid": 2}]
+
+
+def test_update_records_missing_records(logged_in_client):
+    resp = logged_in_client.post("/releases/cms/1/update_records", json={})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "No records provided"
+
+
+def test_update_records_rejects_non_list(logged_in_client):
+    resp = logged_in_client.post(
+        "/releases/cms/1/update_records",
+        json={"records": {"recid": 1}},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Records must be a list"
 
 
 @patch("cernopendata.modules.releases.views._get_release", return_value=MagicMock())
@@ -1449,6 +1494,20 @@ def test_release_upload_url_source_fetch_failure(
     assert "Could not reach the URL" in response.get_json()["error"]
 
 
+@patch(
+    "cernopendata.modules.releases.views.curator_experiments",
+    return_value={"curator_experiments": ["cms"]},
+)
+@patch(
+    "cernopendata.modules.releases.views.Release.validate_experiment",
+    return_value=True,
+)
+def test_release_upload_invalid_source(mock_validate, mock_curator, logged_in_client):
+    response = logged_in_client.post("/releases/cms", data={"source": "bogus"})
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid source"
+
+
 @patch("cernopendata.modules.releases.views._get_release")
 def test_list_images_iterdir_raising_oserror_logs_and_skips(
     mock_get_release, logged_in_client, images_path, monkeypatch
@@ -1559,3 +1618,38 @@ def test_publish_dispatches_task(
     assert resp.status_code == 302
     mock_publish_release.delay.assert_called_once()
     mock_release.publish.assert_not_called()
+
+
+@patch("cernopendata.modules.releases.views._get_release")
+def test_bulk_edit_apply_form_source(mock_get_release, logged_in_client):
+    mock_release = MagicMock()
+    mock_release.bulk_update.return_value = 3
+    mock_get_release.return_value = mock_release
+
+    resp = logged_in_client.post(
+        "/releases/cms/1/bulk_records/apply",
+        data={"updates": json.dumps({"experiment": "CMS"})},
+    )
+
+    assert resp.status_code == 302
+    mock_release.bulk_update.assert_called_once()
+    updates = mock_release.bulk_update.call_args[0][0]
+    assert updates == {"experiment": "CMS"}
+
+
+def test_bulk_edit_apply_form_source_invalid_json(logged_in_client):
+    resp = logged_in_client.post(
+        "/releases/cms/1/bulk_records/apply",
+        data={"updates": "{not valid json"},
+    )
+    assert resp.status_code == 400
+    assert "Invalid JSON" in resp.get_json()["error"]
+
+
+def test_bulk_edit_apply_missing_updates(logged_in_client):
+    resp = logged_in_client.post(
+        "/releases/cms/1/bulk_records/apply",
+        json={},
+    )
+    assert resp.status_code == 400
+    assert "Missing updates" in resp.get_json()["error"]


### PR DESCRIPTION
Resolves #324 
- feat(releases): add table sorting/filtering and redesign the releases page
<img width="2550" height="690" alt="image" src="https://github.com/user-attachments/assets/069cb04c-c9de-44de-b78f-6b6aaf30f954" />

- fix(releases): make discussion link visible in release view
<img width="1635" height="330" alt="image" src="https://github.com/user-attachments/assets/2f49f977-ed2a-4329-a220-da56f1c6c45e" />
