### PR TITLE
Various UI improvements for releases

### DIFF
--- a/cernopendata/modules/releases/views.py
+++ b/cernopendata/modules/releases/views.py
@@ -227,7 +227,7 @@ def release_upload(experiment):
     elif source == "url":
         url = request.form.get("url")
         if not url:
-            abort(400, "Missing URL")
+            return jsonify({"error": "Missing URL"}), 400
 
         try:
             payload = _fetch_json(url)
@@ -236,7 +236,7 @@ def release_upload(experiment):
         source_filename = url.rsplit("/", 1)[-1]
 
     else:
-        abort(400, "Invalid source")
+        return jsonify({"error": "Invalid source"}), 400
 
     records, documents = _split_payload(payload, source_filename)
 
@@ -356,19 +356,18 @@ def update_records(experiment, release_id):
     """Update the records of a release."""
     # Get JSON string from form
 
-    data = request.get_json(silent=True)
-    if not data["records"]:
-        flash("No records provided", "error")
-        abort(400, "No records provided")
+    data = request.get_json(silent=True) or {}
+    records = data.get("records")
+    if not records:
+        return jsonify({"error": "No records provided"}), 400
 
-    if not isinstance(data["records"], list):
-        flash("Records must be a list", "error")
-        abort(400, "Records must be a list")
+    if not isinstance(records, list):
+        return jsonify({"error": "Records must be a list"}), 400
+
     release = _get_release(experiment, release_id, lock=ReleaseStatus.EDITING)
-    release.update_records(data["records"], current_user)
+    release.update_records(records, current_user)
 
-    flash("Records updated successfully.", "success")
-    return redirect(f"/releases/{experiment}/{release_id}")
+    return jsonify({"status": "ok"})
 
 
 @blueprint.route(
@@ -451,7 +450,7 @@ def add_documents(experiment, release_id):
     """Add documents to a release."""
     data = request.get_json(silent=True)
     if not data:
-        abort(400, "Missing request body")
+        return jsonify({"error": "Missing request body"}), 400
 
     release = _get_release(experiment, release_id)
     source = data.get("source", "json")
@@ -459,7 +458,7 @@ def add_documents(experiment, release_id):
     if source == "urls":
         urls = data.get("urls", [])
         if not urls:
-            abort(400, "Missing URLs")
+            return jsonify({"error": "Missing URLs"}), 400
         json_docs = []
         for url in urls:
             clean_url = url.split("?")[0]
@@ -485,7 +484,7 @@ def add_documents(experiment, release_id):
     else:
         docs = data.get("documents")
         if not docs or not isinstance(docs, list):
-            abort(400, "Missing or invalid documents")
+            return jsonify({"error": "Missing or invalid documents"}), 400
 
     for doc in docs:
         content = doc.get("body", {}).get("content", "")
@@ -516,7 +515,7 @@ def add_records(experiment, release_id):
     """Add records to a release."""
     data = request.get_json(silent=True)
     if not data:
-        abort(400, "Missing request body")
+        return jsonify({"error": "Missing request body"}), 400
 
     release = _get_release(experiment, release_id)
     source = data.get("source", "json")
@@ -524,7 +523,7 @@ def add_records(experiment, release_id):
     if source == "url":
         url = data.get("url")
         if not url:
-            abort(400, "Missing URL")
+            return jsonify({"error": "Missing URL"}), 400
         try:
             payload = _fetch_json(url)
         except URLFetchError as e:
@@ -532,11 +531,11 @@ def add_records(experiment, release_id):
     else:
         payload = data.get("records")
         if payload is None:
-            abort(400, "Missing records")
+            return jsonify({"error": "Missing records"}), 400
 
     records = _normalise_payload(payload)
     if not isinstance(records, list):
-        abort(400, "Records must be a list")
+        return jsonify({"error": "Records must be a list"}), 400
 
     release.add_records(records, current_user)
 
@@ -558,13 +557,13 @@ def upload_image(experiment, release_id):
     """Upload one or more images attached to a parent document."""
     parent_slug = request.form.get("parent_slug")
     if not parent_slug:
-        abort(400, "Missing parent_slug")
+        return jsonify({"error": "Missing parent_slug"}), 400
 
     files = [
         image for image in request.files.getlist("images") if image and image.filename
     ]
     if not files:
-        abort(400, "No image files provided")
+        return jsonify({"error": "No image files provided"}), 400
 
     release = _get_release(experiment, release_id)
 
@@ -573,7 +572,10 @@ def upload_image(experiment, release_id):
         None,
     )
     if not parent:
-        abort(400, f"No document with slug '{parent_slug}' in release")
+        return (
+            jsonify({"error": f"No document with slug '{parent_slug}' in release"}),
+            400,
+        )
 
     images_root = Path(current_app.config["CERNOPENDATA_IMAGES_PATH"]).resolve()
     release_dir = (images_root / str(release_id)).resolve()
@@ -581,7 +583,7 @@ def upload_image(experiment, release_id):
     try:
         target_dir.relative_to(release_dir)
     except ValueError:
-        abort(400, "Invalid parent_slug")
+        return jsonify({"error": "Invalid parent_slug"}), 400
     try:
         target_dir.mkdir(parents=True, exist_ok=True)
         already_existing = {p.name for p in target_dir.iterdir()}
@@ -592,7 +594,7 @@ def upload_image(experiment, release_id):
     for file in files:
         filename = secure_filename(file.filename or "").lower()
         if not filename:
-            abort(400, "Invalid filename")
+            return jsonify({"error": "Invalid filename"}), 400
         extension = Path(filename).suffix.lower()
         if extension not in ALLOWED_IMAGE_EXTENSIONS:
             return (
@@ -618,7 +620,7 @@ def upload_image(experiment, release_id):
         try:
             target_path.relative_to(target_dir)
         except ValueError:
-            abort(400, "Invalid filename")
+            return jsonify({"error": "Invalid filename"}), 400
 
         if filename in already_existing:
             return (
@@ -702,7 +704,10 @@ def delete_image(experiment, release_id, parent_slug, filename):
         None,
     )
     if not parent:
-        abort(404, f"No document with slug '{parent_slug}' in release")
+        return (
+            jsonify({"error": f"No document with slug '{parent_slug}' in release"}),
+            404,
+        )
 
     images_root = Path(current_app.config["CERNOPENDATA_IMAGES_PATH"]).resolve()
     release_dir = (images_root / str(release_id)).resolve()
@@ -710,19 +715,19 @@ def delete_image(experiment, release_id, parent_slug, filename):
     try:
         slug_dir.relative_to(release_dir)
     except ValueError:
-        abort(400, "Invalid parent_slug")
+        return jsonify({"error": "Invalid parent_slug"}), 400
 
     safe_filename = secure_filename(filename)
     if not safe_filename:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
     target_path = (slug_dir / safe_filename).resolve()
     try:
         target_path.relative_to(slug_dir)
     except ValueError:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
 
     if not target_path.is_file():
-        abort(404, "Image not found")
+        return jsonify({"error": "Image not found"}), 404
 
     try:
         target_path.unlink()
@@ -750,7 +755,7 @@ def rename_image(experiment, release_id, parent_slug, filename):
     data = request.get_json(silent=True) or {}
     new_filename = data.get("filename")
     if not new_filename:
-        abort(400, "Missing filename")
+        return jsonify({"error": "Missing filename"}), 400
 
     release = _get_release(experiment, release_id)
 
@@ -759,7 +764,10 @@ def rename_image(experiment, release_id, parent_slug, filename):
         None,
     )
     if not parent:
-        abort(404, f"No document with slug '{parent_slug}' in release")
+        return (
+            jsonify({"error": f"No document with slug '{parent_slug}' in release"}),
+            404,
+        )
 
     images_root = Path(current_app.config["CERNOPENDATA_IMAGES_PATH"]).resolve()
     release_dir = (images_root / str(release_id)).resolve()
@@ -767,12 +775,12 @@ def rename_image(experiment, release_id, parent_slug, filename):
     try:
         slug_dir.relative_to(release_dir)
     except ValueError:
-        abort(400, "Invalid parent_slug")
+        return jsonify({"error": "Invalid parent_slug"}), 400
 
     safe_old = secure_filename(filename).lower()
     safe_new = secure_filename(new_filename).lower()
     if not safe_old or not safe_new:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
 
     new_extension = Path(safe_new).suffix.lower()
     if new_extension not in ALLOWED_IMAGE_EXTENSIONS:
@@ -787,10 +795,10 @@ def rename_image(experiment, release_id, parent_slug, filename):
         source_path.relative_to(slug_dir)
         target_path.relative_to(slug_dir)
     except ValueError:
-        abort(400, "Invalid filename")
+        return jsonify({"error": "Invalid filename"}), 400
 
     if not source_path.is_file():
-        abort(404, "Image not found")
+        return jsonify({"error": "Image not found"}), 404
 
     if target_path == source_path:
         return jsonify(
@@ -841,10 +849,10 @@ def update_document(experiment, release_id, slug):
     """Update a document in a release."""
     data = request.get_json(silent=True)
     if not data:
-        abort(400, "Missing request body")
+        return jsonify({"error": "Missing request body"}), 400
     updated_doc = data.get("document")
     if not updated_doc:
-        abort(400, "Missing document data")
+        return jsonify({"error": "Missing document data"}), 400
 
     release = _get_release(experiment, release_id)
     try:
@@ -890,10 +898,10 @@ def bulk_edit_records_apply(experiment, release_id):
         try:
             updates = json.loads(request.form["updates"])
         except ValueError:
-            abort(400, "Invalid JSON in upload")
+            return jsonify({"error": "Invalid JSON in upload"}), 400
 
     if not updates:
-        abort(400, "Missing updates")
+        return jsonify({"error": "Missing updates"}), 400
 
     release = _get_release(experiment, release_id, lock=ReleaseStatus.EDITING)
     diff = release.bulk_update(updates, current_user)
@@ -952,7 +960,7 @@ def preview_record():
     """Preview a record."""
     data = request.json
     if not data or not isinstance(data, dict):
-        abort(400, description="Invalid JSON payload")
+        return jsonify({"error": "Invalid JSON payload"}), 400
     return {
         "html": render_template(
             [
@@ -971,7 +979,7 @@ def preview_document():
     """Preview a document."""
     data = request.json
     if not data or not isinstance(data, dict):
-        abort(400, description="Invalid JSON payload")
+        return jsonify({"error": "Invalid JSON payload"}), 400
     return {
         "html": render_template(
             ["cernopendata_records_ui/docs/detail.html"],

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
@@ -115,6 +115,10 @@ $(document).on("click", "#history-button", function () {
   $("#history-modal").modal("show");
 });
 
+$("#delete-release-action").on("click", function () {
+  $("#delete-release-form").submit();
+});
+
 $("#edit-metadata-action").on("click", function () {
   $("#meta-name").val($("#release-name").text() || "");
   $("#meta-link").val($("#release-discussion-url").attr("href") || "");

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/CurateApp.js
@@ -15,6 +15,9 @@ if (container) {
   $("#create-release-modal .ui.checkbox").checkbox();
 
   $("#open-create-release").on("click", () => {
+    $("#create-release-form")[0].reset();
+    $("#create-release-error").hide().text("");
+    updateSource();
     $("#create-release-modal").modal("show");
   });
 

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleaseContent.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleaseContent.js
@@ -17,6 +17,9 @@ export default function ReleaseContent({
   const showDoiWarning =
     releaseStatus === "STAGED" && records.some((record) => !record.doi);
 
+  const defaultActiveIndex =
+    initialRecords.length === 0 && initialDocuments.length > 0 ? 1 : 0;
+
   const panes = [
     {
       menuItem: { key: "records", icon: "database", content: "Records" },
@@ -65,7 +68,7 @@ export default function ReleaseContent({
           </p>
         </div>
       )}
-      <Tab panes={panes} />
+      <Tab panes={panes} defaultActiveIndex={defaultActiveIndex} />
     </div>
   );
 }

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/DocumentsTable.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/DocumentsTable.js
@@ -5,7 +5,7 @@ import EditDocumentModal from "./EditDocumentModal";
 import UploadImagesModal from "./UploadImagesModal";
 import EditImageModal from "./EditImageModal";
 import PreviewImageModal from "./PreviewImageModal";
-import usePagination from "../shared/usePagination";
+import { usePagination } from "../shared/utils";
 import RowActions from "../shared/RowActions";
 
 export default function DocumentsTable({

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, TextArea, Tab, Button, Icon } from "semantic-ui-react";
+import {
+  Modal,
+  Form,
+  TextArea,
+  Tab,
+  Button,
+  Icon,
+  Message,
+} from "semantic-ui-react";
 import PreviewTab from "../shared/PreviewTab";
+import { fetchJson } from "../shared/utils";
 
 export default function EditDocumentModal({
   doc,
@@ -11,6 +20,7 @@ export default function EditDocumentModal({
 }) {
   const [metaDataBuffer, setMetaDataBuffer] = useState("");
   const [bodyBuffer, setBodyBuffer] = useState("");
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!doc) return;
@@ -22,14 +32,17 @@ export default function EditDocumentModal({
     }
     setMetaDataBuffer(JSON.stringify(metaData, null, 2));
     setBodyBuffer(body?.content || "");
+    setError(null);
   }, [doc]);
 
   const handleSave = async () => {
+    setError(null);
+
     let updated;
     try {
       updated = JSON.parse(metaDataBuffer);
     } catch (e) {
-      alert("Invalid JSON: " + e.message);
+      setError("Invalid JSON: " + e.message);
       return;
     }
     updated.body = {
@@ -39,7 +52,7 @@ export default function EditDocumentModal({
     };
 
     try {
-      const response = await fetch(
+      await fetchJson(
         `/releases/${experiment}/${releaseId}/documents/${doc.slug}`,
         {
           method: "PUT",
@@ -47,13 +60,8 @@ export default function EditDocumentModal({
           body: JSON.stringify({ document: updated }),
         },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        alert("Failed to save: " + (err.error || response.statusText));
-        return;
-      }
     } catch (e) {
-      alert("Failed to save: " + e.message);
+      setError(e.message);
       return;
     }
 
@@ -77,6 +85,11 @@ export default function EditDocumentModal({
     <Modal open={!!doc} onClose={onClose} closeIcon size="large">
       <Modal.Header>Edit Document</Modal.Header>
       <Modal.Content scrolling>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Form>
           <Tab
             panes={[

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditDocumentModal.js
@@ -83,7 +83,9 @@ export default function EditDocumentModal({
 
   return (
     <Modal open={!!doc} onClose={onClose} closeIcon size="large">
-      <Modal.Header>Edit Document</Modal.Header>
+      <Modal.Header>
+        {doc?.slug ? `Edit document ${doc.slug}` : "Edit document"}
+      </Modal.Header>
       <Modal.Content scrolling>
         {error && (
           <Message negative>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
@@ -55,7 +55,7 @@ export default function EditImageModal({
 
   return (
     <Modal open={!!image} onClose={onClose} closeIcon size="small">
-      <Modal.Header>Edit Image</Modal.Header>
+      <Modal.Header>Edit image</Modal.Header>
       <Modal.Content>
         {error && (
           <Message negative>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/EditImageModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Input, Button, Icon } from "semantic-ui-react";
+import { Modal, Form, Input, Button, Icon, Message } from "semantic-ui-react";
+import { fetchJson } from "../shared/utils";
 
 export default function EditImageModal({
   image,
@@ -10,35 +11,34 @@ export default function EditImageModal({
   onDeleted,
 }) {
   const [name, setName] = useState("");
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (image) setName(image.filename);
+    setError(null);
   }, [image]);
 
   const handleDelete = async () => {
     if (!window.confirm(`Delete ${image.filename}?`)) return;
+    setError(null);
     try {
-      const response = await fetch(
+      await fetchJson(
         `/releases/${experiment}/${releaseId}/images/${image.parent_slug}/${image.filename}`,
         { method: "DELETE" },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        alert("Failed to delete: " + (err.error || response.statusText));
-        return;
-      }
       onDeleted(image);
       onClose();
     } catch (e) {
-      alert("Failed to delete: " + e.message);
+      setError(e.message);
     }
   };
 
   const handleRename = async () => {
     const newName = name.trim();
     if (!newName || newName === image.filename) return;
+    setError(null);
     try {
-      const response = await fetch(
+      const result = await fetchJson(
         `/releases/${experiment}/${releaseId}/images/${image.parent_slug}/${image.filename}`,
         {
           method: "PUT",
@@ -46,16 +46,10 @@ export default function EditImageModal({
           body: JSON.stringify({ filename: newName }),
         },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        alert("Failed to rename: " + (err.error || response.statusText));
-        return;
-      }
-      const result = await response.json();
       onRenamed(image, result.image);
       onClose();
     } catch (e) {
-      alert("Failed to rename: " + e.message);
+      setError(e.message);
     }
   };
 
@@ -63,6 +57,11 @@ export default function EditImageModal({
     <Modal open={!!image} onClose={onClose} closeIcon size="small">
       <Modal.Header>Edit Image</Modal.Header>
       <Modal.Content>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Form>
           <Form.Field>
             <label htmlFor="image-edit-name">Filename</label>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/UploadImagesModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/documents/UploadImagesModal.js
@@ -7,6 +7,7 @@ import {
   Button,
   Icon,
 } from "semantic-ui-react";
+import { fetchJson } from "../shared/utils";
 
 export default function UploadImagesModal({
   open,
@@ -52,17 +53,10 @@ export default function UploadImagesModal({
         formData.append("images", file);
       }
 
-      const response = await fetch(
+      const result = await fetchJson(
         `/releases/${experiment}/${releaseId}/upload_image`,
         { method: "POST", body: formData },
       );
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || "Failed to upload images");
-      }
-
-      const result = await response.json();
       onUploaded(result.images || []);
       onClose();
     } catch (e) {
@@ -112,7 +106,11 @@ export default function UploadImagesModal({
               }
             />
           </Form.Field>
-          {error && <Message negative>{error}</Message>}
+          {error && (
+            <Message negative>
+              <Icon name="warning circle" /> {error}
+            </Message>
+          )}
         </Form>
       </Modal.Content>
       <Modal.Actions>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/BulkEditModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/BulkEditModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Table, Button, Icon } from "semantic-ui-react";
+import { Modal, Form, Table, Button, Icon, Message } from "semantic-ui-react";
+import { fetchJson } from "../shared/utils";
 
 function DiffObject({ diff }) {
   return (
@@ -67,12 +68,14 @@ export default function BulkEditModal({
   const [bulkActions, setBulkActions] = useState([]);
   const [bulkPreview, setBulkPreview] = useState([]);
   const [bulkPreviewDone, setBulkPreviewDone] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!open) return;
     setBulkActions([]);
     setBulkPreview([]);
     setBulkPreviewDone(false);
+    setError(null);
   }, [open]);
 
   function addBulkRow() {
@@ -120,68 +123,68 @@ export default function BulkEditModal({
 
   async function previewBulk() {
     if (bulkActions.length === 0) return;
+    setError(null);
 
     let updates;
     try {
       updates = collectBulkOperations();
     } catch (e) {
-      alert(e.message);
+      setError(e.message);
       return;
     }
 
-    const res = await fetch(
-      `/releases/${experiment}/${releaseId}/bulk_records/preview`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ updates }),
-      },
-    );
-
-    if (!res.ok) {
-      const json = await res.json().catch(() => ({}));
-      alert(json.error || "Preview failed");
-      return;
+    try {
+      const data = await fetchJson(
+        `/releases/${experiment}/${releaseId}/bulk_records/preview`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates }),
+        },
+      );
+      setBulkPreview(data.diffs || []);
+      setBulkPreviewDone(true);
+    } catch (e) {
+      setError(e.message);
     }
-
-    const data = await res.json();
-    setBulkPreview(data.diffs || []);
-    setBulkPreviewDone(true);
   }
 
   async function applyBulk() {
     if (!bulkPreviewDone) return;
+    setError(null);
 
     let updates;
     try {
       updates = collectBulkOperations();
     } catch (e) {
-      alert(e.message);
+      setError(e.message);
       return;
     }
 
-    const res = await fetch(
-      `/releases/${experiment}/${releaseId}/bulk_records/apply`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ updates }),
-      },
-    );
-
-    if (!res.ok) {
-      const json = await res.json().catch(() => ({}));
-      alert(json.error || "Apply failed");
-      return;
+    try {
+      await fetchJson(
+        `/releases/${experiment}/${releaseId}/bulk_records/apply`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates }),
+        },
+      );
+      window.location.reload();
+    } catch (e) {
+      setError(e.message);
     }
-
-    window.location.reload();
   }
 
   return (
     <Modal open={open} onClose={onClose} closeIcon size="fullscreen">
       <Modal.Header>Bulk edit records</Modal.Header>
       <Modal.Content>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Form>
           <Table celled compact size="small">
             <thead>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
@@ -201,7 +201,7 @@ export default function EditRecordModal({
       <Modal.Actions>
         <Button onClick={onClose}>Cancel</Button>
         <Button primary onClick={handleSave}>
-          Save
+          <Icon name="save" /> Save
         </Button>
       </Modal.Actions>
     </Modal>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/EditRecordModal.js
@@ -1,9 +1,18 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { Modal, Form, TextArea, Tab, Button, Message } from "semantic-ui-react";
+import {
+  Modal,
+  Form,
+  TextArea,
+  Tab,
+  Button,
+  Message,
+  Icon,
+} from "semantic-ui-react";
 import { AutoForm } from "uniforms-semantic";
 import PreviewTab from "../shared/PreviewTab";
 import SchemaNode from "./SchemaNode";
 import createBridge from "./schema";
+import { fetchJson } from "../shared/utils";
 
 export default function EditRecordModal({
   editingRecord,
@@ -19,6 +28,12 @@ export default function EditRecordModal({
   const [bridge, setBridge] = useState(null);
   const [origSchema, setOrigSchema] = useState(null);
   const [schemaError, setSchemaError] = useState(false);
+  const [error, setError] = useState(null);
+
+  const open = !!editingRecord || editAllMode;
+  useEffect(() => {
+    if (open) setError(null);
+  }, [open]);
 
   useEffect(() => {
     fetch("/schema/records/record-v1.0.0.json")
@@ -136,52 +151,51 @@ export default function EditRecordModal({
     },
   ];
 
-  const handleSave = () => {
-    const updatedRecords = editAllMode
-      ? records
-      : (() => {
-          if (
-            editingIndex == null ||
-            editingIndex < 0 ||
-            editingIndex >= records.length
-          ) {
-            alert("Record not found");
-            return records;
-          }
-          const copy = [...records];
-          copy[editingIndex] = editingRecord;
-          return copy;
-        })();
+  const handleSave = async () => {
+    setError(null);
 
-    fetch(`/releases/${experiment}/${releaseId}/update_records`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ records: updatedRecords }),
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          const json = await response.json().catch(() => ({}));
-          throw new Error(json.error || "Save failed");
-        }
-        setRecords(updatedRecords);
-        onClose();
-      })
-      .catch((err) => alert(err.message));
+    let updatedRecords;
+    if (editAllMode) {
+      updatedRecords = records;
+    } else {
+      if (
+        editingIndex == null ||
+        editingIndex < 0 ||
+        editingIndex >= records.length
+      ) {
+        setError("Record not found.");
+        return;
+      }
+      updatedRecords = [...records];
+      updatedRecords[editingIndex] = editingRecord;
+    }
+
+    try {
+      await fetchJson(`/releases/${experiment}/${releaseId}/update_records`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ records: updatedRecords }),
+      });
+      setRecords(updatedRecords);
+      onClose();
+    } catch (e) {
+      setError(e.message);
+    }
   };
 
   return (
-    <Modal
-      open={!!editingRecord || editAllMode}
-      onClose={onClose}
-      closeIcon
-      size="fullscreen"
-    >
+    <Modal open={open} onClose={onClose} closeIcon size="fullscreen">
       <Modal.Header>
         {editAllMode
           ? "Edit all records"
           : `Edit record ${editingRecord?.recid}`}
       </Modal.Header>
       <Modal.Content>
+        {error && (
+          <Message negative>
+            <Icon name="warning circle" /> {error}
+          </Message>
+        )}
         <Tab panes={panes} />
       </Modal.Content>
       <Modal.Actions>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/RecordsTable.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/records/RecordsTable.js
@@ -1,10 +1,17 @@
 import React, { useEffect, useState, useRef } from "react";
-import { Table, Button, Icon, Pagination, Popup } from "semantic-ui-react";
+import {
+  Table,
+  Button,
+  Icon,
+  Pagination,
+  Popup,
+  Message,
+} from "semantic-ui-react";
 import EditRecordModal from "./EditRecordModal";
 import BulkEditModal from "./BulkEditModal";
 import AddItemsModal from "../shared/AddItemsModal";
-import usePagination from "../shared/usePagination";
 import RowActions from "../shared/RowActions";
+import { fetchJson, usePagination } from "../shared/utils";
 
 export default function RecordsTable({
   experiment,
@@ -30,17 +37,19 @@ export default function RecordsTable({
   const [bulkModalOpen, setBulkModalOpen] = useState(false);
   const [doiLoading, setDoiLoading] = useState(false);
   const [doiErrors, setDoiErrors] = useState([]);
+  const [error, setError] = useState(null);
 
   const allHaveDoi =
     records.length > 0 && records.every((record) => record.doi);
 
   async function handleGenerateDoi() {
     setDoiLoading(true);
+    setError(null);
     const recidsWithoutDoi = records
       .filter((record) => !record.doi)
       .map((record) => record.recid);
     try {
-      const response = await fetch(
+      const data = await fetchJson(
         `/releases/${experiment}/${releaseId}/generate_doi`,
         {
           method: "POST",
@@ -48,15 +57,10 @@ export default function RecordsTable({
           body: JSON.stringify({ recids: recidsWithoutDoi }),
         },
       );
-      if (!response.ok) {
-        const json = await response.json().catch(() => ({}));
-        throw new Error(json.error || "Request failed");
-      }
-      const data = await response.json();
       setRecords(data.records);
       setDoiErrors(data.errors || []);
     } catch (err) {
-      alert(err.message);
+      setError(err.message);
     } finally {
       setDoiLoading(false);
     }
@@ -84,6 +88,11 @@ export default function RecordsTable({
 
   return (
     <>
+      {error && (
+        <Message negative>
+          <Icon name="warning circle" /> {error}
+        </Message>
+      )}
       {doiErrors.length > 0 && (
         <div className="ui segment validation-segment">
           <div className="validation-header">
@@ -94,9 +103,9 @@ export default function RecordsTable({
               <span className="ui red label">{doiErrors.length} failed</span>
             </div>
           </div>
-          {doiErrors.map((error, index) => (
+          {doiErrors.map((validationError, index) => (
             <div
-              key={error.recid}
+              key={validationError.recid}
               className={`validation-row${index < doiErrors.length - 1 ? " validation-row-bordered" : ""}`}
             >
               <div className="validation-row-icon">
@@ -104,7 +113,7 @@ export default function RecordsTable({
               </div>
               <div className="validation-row-body">
                 <b>
-                  recid {error.recid}: {error.error}
+                  recid {validationError.recid}: {validationError.error}
                 </b>
               </div>
             </div>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/AddItemsModal.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/AddItemsModal.js
@@ -12,6 +12,7 @@ import {
   rewriteDocLinks,
   slugFromFilename,
 } from "../documents/rewriteDocLinks";
+import { fetchJson } from "./utils";
 
 const CONFIG = {
   documents: {
@@ -132,7 +133,7 @@ export default function AddItemsModal({
     setLoading(true);
     try {
       const requestBody = await buildRequestBody();
-      const response = await fetch(
+      const result = await fetchJson(
         `/releases/${experiment}/${releaseId}/${endpoint}`,
         {
           method: "POST",
@@ -140,11 +141,6 @@ export default function AddItemsModal({
           body: JSON.stringify(requestBody),
         },
       );
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || `Failed to save ${collection}`);
-      }
-      const result = await response.json();
       onAdded(result[collection] || []);
       onClose();
     } catch (e) {
@@ -279,7 +275,11 @@ export default function AddItemsModal({
             </Form.Field>
           )}
 
-          {error && <Message negative>{error}</Message>}
+          {error && (
+            <Message negative>
+              <Icon name="warning circle" /> {error}
+            </Message>
+          )}
         </Form>
       </Modal.Content>
       <Modal.Actions>

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/PreviewTab.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/PreviewTab.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Loader, Message } from "semantic-ui-react";
+import { Loader, Message, Icon } from "semantic-ui-react";
 
 export default function PreviewTab({ endpoint, data }) {
   const [html, setHtml] = useState("");
@@ -52,7 +52,11 @@ export default function PreviewTab({ endpoint, data }) {
   return (
     <div>
       {loading && <Loader active inline="centered" />}
-      {error && <Message negative>{error}</Message>}
+      {error && (
+        <Message negative>
+          <Icon name="warning circle" /> {error}
+        </Message>
+      )}
       <div
         style={{ marginTop: 10 }}
         dangerouslySetInnerHTML={{ __html: html }}

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/usePagination.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/usePagination.js
@@ -1,8 +1,0 @@
-import { useState } from "react";
-
-export default function usePagination(items, pageSize = 5) {
-  const [page, setPage] = useState(0);
-  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
-  const visible = items.slice(page * pageSize, (page + 1) * pageSize);
-  return { page, setPage, visible, totalPages };
-}

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/utils.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/shared/utils.js
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+export async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || `Request failed (${response.status})`);
+  }
+  return response.json();
+}
+
+export function usePagination(items, pageSize = 5) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const visible = items.slice(page * pageSize, (page + 1) * pageSize);
+  return { page, setPage, visible, totalPages };
+}

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -588,6 +588,10 @@ a {
     line-height: 1.3;
 }
 
+.ui.dropdown .menu > .release-delete-item:not(.disabled) {
+    color: #db2828 !important;
+}
+
 .release-summary-segment {
     padding: 1.5em 2em;
 

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -744,9 +744,18 @@ a {
 
 .validation-row-actions {
     flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
+    display: grid;
+    column-gap: 1.5em;
+}
+
+.validation-segment:has(.validation-row-actions > .ui.label) {
+    .validation-row-actions {
+        grid-template-columns: 7.5em 7em;
+
+        > .ui.label {
+            grid-column: 2;
+        }
+    }
 }
 
 .validation-autofix-message {

--- a/cernopendata/templates/cernopendata_pages/release_details/_summary.html
+++ b/cernopendata/templates/cernopendata_pages/release_details/_summary.html
@@ -64,7 +64,7 @@
     <i class="close icon"></i>
 
     <div class="header">
-        Release History
+        Release history
     </div>
 
     <div class="scrolling content">
@@ -120,6 +120,9 @@
 
     <div class="actions">
         <div class="ui cancel button">Cancel</div>
-        <div class="ui primary button" id="save-metadata">Save</div>
+        <div class="ui primary button" id="save-metadata">
+            <i class="save icon"></i>
+            Save
+        </div>
     </div>
 </div>

--- a/cernopendata/templates/cernopendata_pages/release_details/_summary.html
+++ b/cernopendata/templates/cernopendata_pages/release_details/_summary.html
@@ -29,15 +29,12 @@
                 <div class="item" id="edit-metadata-action">
                     Edit metadata
                 </div>
-                <div>
-                    <form action="/releases/{{ release._metadata.experiment }}/{{ release._metadata.id }}/delete"
-                          method="POST">
-                        <button class="ui red button {% if release._metadata.status not in ['READY', 'DRAFT'] %}disabled{% endif %}"
-                                {% if release._metadata.status not in ['READY', 'DRAFT'] %}disabled{% endif %} type="submit">
-                            Delete release
-                        </button>
-                    </form>
+                <div class="item release-delete-item {% if release._metadata.status not in ['READY', 'DRAFT'] %}disabled{% endif %}"
+                     id="delete-release-action">
+                    <b>Delete release</b>
                 </div>
+                <form id="delete-release-form" method="POST"
+                      action="/releases/{{ release._metadata.experiment }}/{{ release._metadata.id }}/delete"></form>
             </div>
         </div>
     </div>

--- a/cernopendata/templates/cernopendata_pages/releases.html
+++ b/cernopendata/templates/cernopendata_pages/releases.html
@@ -80,6 +80,7 @@
                         id="uploadButton"
                         class="ui primary button disabled"
                         type="submit">
+                    <i class="plus icon"></i>
                     Create release
                 </button>
             </form>

--- a/tests/releases/test_views.py
+++ b/tests/releases/test_views.py
@@ -51,22 +51,35 @@ def test_invalid_experiment(client):
     assert resp.status_code in (403, 404)
 
 
-def test_upload_url(client, monkeypatch):
-    class FakeResp:
-        def json(self):
-            return {"x": 1}
+@patch("cernopendata.modules.releases.views.Release.create")
+@patch("cernopendata.modules.releases.views.curator_experiments")
+@patch("cernopendata.modules.releases.views.Release.validate_experiment")
+def test_upload_url(
+    mock_validate_exp, mock_curator_exps, mock_create, logged_in_client, monkeypatch
+):
+    mock_validate_exp.return_value = True
+    mock_curator_exps.return_value = {"curator_experiments": ["cms"]}
+    mock_create.return_value = MagicMock(_metadata=MagicMock(id=99))
 
-        def raise_for_status(self):
-            return None
+    records = [{"recid": 1, "experiment": "CMS", "files": []}]
+    monkeypatch.setattr(
+        views.requests,
+        "get",
+        lambda *a, **k: MagicMock(
+            json=lambda: {"records": records},
+            raise_for_status=lambda: None,
+        ),
+    )
 
-    monkeypatch.setattr(views.requests, "get", lambda *a, **k: FakeResp())
-
-    resp = client.post(
+    resp = logged_in_client.post(
         "/releases/cms",
         data={"source": "url", "url": "http://example.com/file.json"},
     )
 
-    assert resp.status_code == 302
+    assert resp.status_code == 200
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("records") == records
+    assert kwargs.get("name") == "file.json"
 
 
 @patch("cernopendata.modules.releases.views._get_release")
@@ -454,6 +467,38 @@ def test_stage_release_dispatches_task(
     assert resp.status_code == 302
     mock_stage_release.delay.assert_called_once()
     mock_release.stage.assert_not_called()
+
+
+@patch("cernopendata.modules.releases.views._get_release")
+def test_update_records_success(mock_get_release, logged_in_client):
+    mock_release = MagicMock()
+    mock_get_release.return_value = mock_release
+
+    resp = logged_in_client.post(
+        "/releases/cms/1/update_records",
+        json={"records": [{"recid": 1}, {"recid": 2}]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+    mock_release.update_records.assert_called_once()
+    updated = mock_release.update_records.call_args[0][0]
+    assert updated == [{"recid": 1}, {"recid": 2}]
+
+
+def test_update_records_missing_records(logged_in_client):
+    resp = logged_in_client.post("/releases/cms/1/update_records", json={})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "No records provided"
+
+
+def test_update_records_rejects_non_list(logged_in_client):
+    resp = logged_in_client.post(
+        "/releases/cms/1/update_records",
+        json={"records": {"recid": 1}},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Records must be a list"
 
 
 @patch("cernopendata.modules.releases.views._get_release", return_value=MagicMock())
@@ -1449,6 +1494,20 @@ def test_release_upload_url_source_fetch_failure(
     assert "Could not reach the URL" in response.get_json()["error"]
 
 
+@patch(
+    "cernopendata.modules.releases.views.curator_experiments",
+    return_value={"curator_experiments": ["cms"]},
+)
+@patch(
+    "cernopendata.modules.releases.views.Release.validate_experiment",
+    return_value=True,
+)
+def test_release_upload_invalid_source(mock_validate, mock_curator, logged_in_client):
+    response = logged_in_client.post("/releases/cms", data={"source": "bogus"})
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid source"
+
+
 @patch("cernopendata.modules.releases.views._get_release")
 def test_list_images_iterdir_raising_oserror_logs_and_skips(
     mock_get_release, logged_in_client, images_path, monkeypatch
@@ -1559,3 +1618,38 @@ def test_publish_dispatches_task(
     assert resp.status_code == 302
     mock_publish_release.delay.assert_called_once()
     mock_release.publish.assert_not_called()
+
+
+@patch("cernopendata.modules.releases.views._get_release")
+def test_bulk_edit_apply_form_source(mock_get_release, logged_in_client):
+    mock_release = MagicMock()
+    mock_release.bulk_update.return_value = 3
+    mock_get_release.return_value = mock_release
+
+    resp = logged_in_client.post(
+        "/releases/cms/1/bulk_records/apply",
+        data={"updates": json.dumps({"experiment": "CMS"})},
+    )
+
+    assert resp.status_code == 302
+    mock_release.bulk_update.assert_called_once()
+    updates = mock_release.bulk_update.call_args[0][0]
+    assert updates == {"experiment": "CMS"}
+
+
+def test_bulk_edit_apply_form_source_invalid_json(logged_in_client):
+    resp = logged_in_client.post(
+        "/releases/cms/1/bulk_records/apply",
+        data={"updates": "{not valid json"},
+    )
+    assert resp.status_code == 400
+    assert "Invalid JSON" in resp.get_json()["error"]
+
+
+def test_bulk_edit_apply_missing_updates(logged_in_client):
+    resp = logged_in_client.post(
+        "/releases/cms/1/bulk_records/apply",
+        json={},
+    )
+    assert resp.status_code == 400
+    assert "Missing updates" in resp.get_json()["error"]


### PR DESCRIPTION
Resolves #375 

- refactor(releases): replace alert popups with inline error messages
<img width="774" height="301" alt="image" src="https://github.com/user-attachments/assets/43f43846-e697-47b2-8c4a-92344bb3bff2" />

- refactor(releases): make the delete action consistent with other menu items
<img width="189" height="205" alt="image" src="https://github.com/user-attachments/assets/72da7da2-1f14-4985-837d-4f8c3bebc7d5" />

- fix(releases): align the toggles in the validations list
<img width="1631" height="255" alt="image" src="https://github.com/user-attachments/assets/e5c62a99-43a2-4a1f-8742-eef9b8c75589" />

- refactor(releases): make modal titles and buttons consistent
- feat(releases): open the documents tab for document-only releases