### PR TITLE
fix(releases): return a 404 page for a non-existent release

### DIFF
--- a/cernopendata/modules/releases/api.py
+++ b/cernopendata/modules/releases/api.py
@@ -287,7 +287,7 @@ class Release:
             id=release_id, experiment=experiment
         ).first()
 
-        return cls(metadata)
+        return cls(metadata) if metadata else None
 
     def is_status(self, status):
         """Check if the release is in a particular status."""

--- a/tests/releases/test_releases.py
+++ b/tests/releases/test_releases.py
@@ -1134,3 +1134,18 @@ def test_publish_collects_datacite_errors(mocker):
     assert "DataCite down" in errors[0]
     assert mock_register.call_count == 2
     mock_session.commit.assert_called_once()
+
+
+def test_get_release(mocker):
+    metadata = MagicMock()
+    mock_query = mocker.patch("cernopendata.modules.releases.api.ReleaseMetadata.query")
+    mock_query.filter_by.return_value.first.return_value = metadata
+
+    release = Release.get("cms", 1)
+
+    assert release._metadata is metadata
+    mock_query.filter_by.assert_called_once_with(id=1, experiment="cms")
+
+    mock_query.filter_by.return_value.first.return_value = None
+
+    assert Release.get("cms", 999999) is None

--- a/tests/releases/test_views.py
+++ b/tests/releases/test_views.py
@@ -1653,3 +1653,25 @@ def test_bulk_edit_apply_missing_updates(logged_in_client):
     )
     assert resp.status_code == 400
     assert "Missing updates" in resp.get_json()["error"]
+
+
+@patch("cernopendata.modules.releases.views.Release.get", return_value=None)
+@patch(
+    "cernopendata.modules.releases.views.curator_experiments",
+    return_value={"curator_experiments": ["cms"]},
+)
+def test_release_detail_not_found(mock_curator_experiments, mock_get, logged_in_client):
+    resp = logged_in_client.get("/releases/cms/999999")
+
+    assert resp.status_code == 404
+
+
+@patch("cernopendata.modules.releases.views.Release.get", return_value=None)
+@patch(
+    "cernopendata.modules.releases.views.curator_experiments",
+    return_value={"curator_experiments": ["cms"]},
+)
+def test_release_stage_not_found(mock_curator_experiments, mock_get, logged_in_client):
+    resp = logged_in_client.post("/releases/cms/999999/stage")
+
+    assert resp.status_code == 404


### PR DESCRIPTION
Resolves #369 