### PR TITLE
Quick fixes

### DIFF
--- a/cernopendata/modules/datacite/serializers.py
+++ b/cernopendata/modules/datacite/serializers.py
@@ -121,7 +121,11 @@ class DataCiteSerializer(Schema):
 
     def get_creator(self, obj):
         """Get creators based on authors or collaboration field."""
-        authors = obj.get("authors", [obj.get("collaboration", None)])
+        authors = obj.get("authors") or []
+        if not authors:
+            collaboration = obj.get("collaboration") or {}
+            if collaboration.get("name"):
+                authors = [collaboration]
         creators = [
             {
                 "name": author["name"],
@@ -138,6 +142,7 @@ class DataCiteSerializer(Schema):
                 ),
             }
             for author in authors
+            if author.get("name")
         ]
         return creators
 

--- a/cernopendata/modules/datacite/utils.py
+++ b/cernopendata/modules/datacite/utils.py
@@ -38,6 +38,11 @@ from .serializers import DataCiteSerializer
 def validate_record(record):
     """Serialize a record to schema43 and validate it."""
     doc = DataCiteSerializer().dump(record)
+    if not doc.get("creators"):
+        raise ValueError(
+            f"Record {record.get('recid')} has neither authors nor a collaboration, "
+            "so DataCite has no creators to register"
+        )
     schema43.validate(doc)
     return schema43.tostring(doc)
 

--- a/cernopendata/modules/fixtures/cli.py
+++ b/cernopendata/modules/fixtures/cli.py
@@ -161,6 +161,7 @@ def create_record(data, skip_files, logger=None):
 def update_record(pid, data, skip_files, logger=None):
     """Updates the given record."""
     record = RecordFilesWithIndex.get_record(pid.object_uuid)
+    file_keys = ["files", "_files", "file_indices", "_file_indices"]
     if not skip_files:
         for o in ObjectVersion.get_by_bucket(record.bucket).all():
             o.remove()
@@ -171,10 +172,13 @@ def update_record(pid, data, skip_files, logger=None):
     for k in list(record.keys()):
         if k in ["_bucket", "pids"]:
             continue
-        if skip_files and k in ["files", "_files", "file_indices", "_file_indices"]:
+        if skip_files and k in file_keys:
             continue
         del record[k]
-    record.update(data)
+    if skip_files:
+        record.update({k: v for k, v in data.items() if k not in file_keys})
+    else:
+        record.update(data)
     if not skip_files:
         _handle_record_files(record, data, logger)
         record.update(data)

--- a/cernopendata/modules/releases/views.py
+++ b/cernopendata/modules/releases/views.py
@@ -102,6 +102,23 @@ def _merge_index_files(record):
     record["files"] = files
 
 
+def _strip_derived_fields(record):
+    """Return the record without the fields derived when it was created."""
+    if not isinstance(record, dict):
+        return record
+    derived_fields = (
+        "_availability_details",
+        "_bucket",
+        "_file_indices",
+        "_files",
+        "bucket",
+        "dataset",
+    )
+    return {
+        field: value for field, value in record.items() if field not in derived_fields
+    }
+
+
 def _normalise_record(record):
     """Normalise a single exported record for release import."""
     if not isinstance(record, dict):
@@ -109,8 +126,7 @@ def _normalise_record(record):
     # In case we are reading from the cernopandata api, where the record is in the 'metadata' field
     if "metadata" in record:
         record = record["metadata"]
-        for field in ("_files", "_bucket", "bucket", "_file_indices"):
-            record.pop(field, None)
+    record = _strip_derived_fields(record)
     if "index_files" in record:
         _merge_index_files(record)
     return record
@@ -133,7 +149,7 @@ def _split_payload(payload, source_filename):
         isinstance(payload.get("records"), list)
         or isinstance(payload.get("documents"), list)
     ):
-        records = payload.get("records") or []
+        records = _normalise_payload(payload.get("records") or [])
         documents = payload.get("documents") or []
     else:
         items = _normalise_payload(payload)
@@ -323,7 +339,7 @@ def release_json(experiment, release_id):
         "name": metadata.name,
         "description": metadata.description,
         "discussion_url": metadata.discussion_url,
-        "records": metadata.records or [],
+        "records": [_strip_derived_fields(record) for record in metadata.records or []],
         "documents": metadata.documents or [],
     }
     filename = _release_download_filename(metadata.name, release_id)

--- a/cernopendata/modules/search/component_templates/os-v2/opendata-record-v1.0.0.json
+++ b/cernopendata/modules/search/component_templates/os-v2/opendata-record-v1.0.0.json
@@ -304,7 +304,12 @@
                   "type": "keyword"
                 },
                 "note": {
-                  "type": "text"
+                  "properties": {
+                    "description": {
+                      "type": "text"
+                    }
+                  },
+                  "type": "object"
                 },
                 "output_dataset": {
                   "type": "text"

--- a/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleasesTable.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/releases/ReleasesTable.js
@@ -180,6 +180,7 @@ export default function ReleasesTable({ experiment }) {
           <Table.Header>
             <Table.Row>
               <Table.HeaderCell
+                className="name-column"
                 sorted={sortedProp("name")}
                 onClick={() => handleSort("name")}
               >
@@ -219,7 +220,7 @@ export default function ReleasesTable({ experiment }) {
               </Table.HeaderCell>
             </Table.Row>
             <Table.Row>
-              <Table.HeaderCell>
+              <Table.HeaderCell className="name-column">
                 <Input
                   fluid
                   icon="search"
@@ -265,7 +266,9 @@ export default function ReleasesTable({ experiment }) {
                   }}
                   style={{ cursor: "pointer" }}
                 >
-                  <Table.Cell>{release.name}</Table.Cell>
+                  <Table.Cell className="name-column">
+                    {release.name}
+                  </Table.Cell>
                   <Table.Cell>
                     <div className="release-step">
                       <span className="release-step-icon">

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/releases.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/releases.scss
@@ -256,6 +256,12 @@
         width: 8em;
     }
 
+    .name-column {
+        width: 34%;
+        overflow-wrap: break-word;
+        word-break: break-word;
+    }
+
     .discussion-column {
         width: 12em;
 

--- a/tests/releases/test_views.py
+++ b/tests/releases/test_views.py
@@ -572,6 +572,24 @@ def test_update_document_slug_not_found(mock_get_release, logged_in_client):
             ],
         ),
         ({"records": [{"recid": 1, "files": []}]}, [{"recid": 1, "files": []}], []),
+        (
+            {
+                "records": [
+                    {
+                        "recid": 1,
+                        "files": [],
+                        "_files": [],
+                        "_bucket": "abc",
+                        "bucket": "def",
+                        "_file_indices": [],
+                        "_availability_details": {},
+                        "dataset": {},
+                    }
+                ]
+            },
+            [{"recid": 1, "files": []}],
+            [],
+        ),
     ],
 )
 def test_split_payload(payload, expected_records, expected_documents):
@@ -1771,3 +1789,31 @@ def test_retry_dois_registers_the_pending_dois(mock_get_release, logged_in_clien
     mock_get_release.assert_called_once_with(
         "cms", 1, status=views.ReleaseStatus.PUBLISHED
     )
+
+
+@patch("cernopendata.modules.releases.views._get_release")
+def test_download_release_strips_the_derived_fields(mock_get_release, client):
+    metadata = MagicMock(
+        description=None,
+        discussion_url=None,
+        records=[
+            {
+                "recid": 1,
+                "experiment": "CMS",
+                "_files": [{"key": "f.root"}],
+                "_file_indices": [],
+                "_availability_details": {"online": 1},
+                "_bucket": "abc",
+                "bucket": "def",
+                "dataset": {},
+            }
+        ],
+        documents=[],
+    )
+    metadata.name = "release-1.json"
+    mock_get_release.return_value = MagicMock(_metadata=metadata)
+
+    resp = client.get("/releases/api/cms/1")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["records"] == [{"recid": 1, "experiment": "CMS"}]

--- a/tests/test_datacite_utils.py
+++ b/tests/test_datacite_utils.py
@@ -16,7 +16,10 @@ def test_validate_record_returns_serialized_doc(mocker):
     )
     mock_schema43 = mocker.patch("cernopendata.modules.datacite.utils.schema43")
 
-    mock_doc = {"titles": [{"title": "Test"}]}
+    mock_doc = {
+        "titles": [{"title": "Test"}],
+        "creators": [{"name": "CMS collaboration"}],
+    }
     mock_serializer_cls.return_value.dump.return_value = mock_doc
     mock_schema43.tostring.return_value = "<resource/>"
 
@@ -32,7 +35,7 @@ def test_validate_record_returns_serialized_doc(mocker):
 def test_validate_record_propagates_schema_errors(mocker):
     mocker.patch(
         "cernopendata.modules.datacite.utils.DataCiteSerializer"
-    ).return_value.dump.return_value = {}
+    ).return_value.dump.return_value = {"creators": [{"name": "CMS collaboration"}]}
     mock_schema43 = mocker.patch("cernopendata.modules.datacite.utils.schema43")
     mock_schema43.validate.side_effect = ValueError("required field missing")
 
@@ -117,3 +120,15 @@ def test_update_record_doi_updates_the_registered_doi(mocker):
         url="https://opendata.cern.ch/record/42", doc="<resource/>"
     )
     mock_provider.register.assert_not_called()
+
+
+def test_validate_record_rejects_a_record_without_creators(mocker):
+    mocker.patch(
+        "cernopendata.modules.datacite.utils.DataCiteSerializer"
+    ).return_value.dump.return_value = {"titles": [{"title": "Test"}], "creators": []}
+    mock_schema43 = mocker.patch("cernopendata.modules.datacite.utils.schema43")
+
+    with pytest.raises(ValueError, match="no creators to register"):
+        validate_record({"recid": "atlas-160004"})
+
+    mock_schema43.tostring.assert_not_called()


### PR DESCRIPTION
- fix(mappings): map methodology.steps.note as an object
- fix(datacite): fall back to the collaboration when authors is empty
- fix(releases): strip the derived fields from records on import and export (resolves #399)
- fix(fixtures): keep the record files when updating with skip_files
- fix(releases): stop long release names overflowing the releases table